### PR TITLE
feat: parser module with fixtures and tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250415.0",
+        "@types/node": "^25.6.0",
         "@vitest/coverage-v8": "^2.1.8",
         "typescript": "^5.7.2",
         "vitest": "^2.1.8",
@@ -1489,6 +1490,17 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "2.1.9",
@@ -2987,12 +2999,20 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unenv": {
       "version": "2.0.0-rc.14",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
       "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "defu": "^6.1.4",
         "exsolve": "^1.0.1",
@@ -3014,6 +3034,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3198,6 +3219,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250415.0",
-        "@types/node": "^25.6.0",
+        "@types/node": "^22.10.0",
         "@vitest/coverage-v8": "^2.1.8",
         "typescript": "^5.7.2",
         "vitest": "^2.1.8",
@@ -1492,14 +1492,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -3000,9 +3000,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250415.0",
+    "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^2.1.8",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "deploy": "wrangler deploy",
     "dev": "wrangler dev"
   },
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250415.0",
-    "@types/node": "^25.6.0",
+    "@types/node": "^22.10.0",
     "@vitest/coverage-v8": "^2.1.8",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,2 +1,141 @@
-// TODO(parser): implement PATTERNS array, extractCode, extractNetflixHouseholdLink.
-export const PATTERNS: readonly never[] = [];
+// Parser module: inspects a ParsedEmail (subject/from/body) and decides
+// which streaming service sent it and whether it contains an OTP code or a
+// household-verification link.
+//
+// Pattern ordering note: `netflix-household` is deliberately listed BEFORE
+// `netflix` so that a household/travel email matches the household pattern
+// first. The plain `netflix` pattern still uses a `subjectBlocklist` as a
+// belt-and-suspenders guard, but ordering makes the intent explicit and
+// robust to future subject-line changes.
+
+export type ServiceKey = 'netflix' | 'netflix-household' | 'disney' | 'max' | 'amazon';
+
+export interface Pattern {
+  service: ServiceKey;
+  senderMatch: RegExp;
+  // Exactly one of codeRegex or linkRegex must be set on any given pattern.
+  codeRegex?: RegExp;
+  linkRegex?: RegExp;
+  // Skip this pattern if the subject matches.
+  subjectBlocklist?: RegExp;
+  // Skip this pattern if the body does NOT match.
+  bodyRequire?: RegExp;
+  validForMinutes: number;
+}
+
+export interface ParsedEmail {
+  from: string;
+  subject: string;
+  text: string;
+  html: string;
+}
+
+export type MatchResult =
+  | { service: ServiceKey; type: 'code'; value: string; validForMinutes: number }
+  | { service: ServiceKey; type: 'household'; value: string; validForMinutes: number };
+
+export const PATTERNS: readonly Pattern[] = [
+  {
+    service: 'netflix-household',
+    senderMatch: /@account\.netflix\.com$|@mailer\.netflix\.com$/i,
+    linkRegex:
+      /https:\/\/(?:www\.)?netflix\.com\/account\/(?:travel|update-primary-location)\/[A-Za-z0-9_\-=?&%./]+/,
+    validForMinutes: 15,
+  },
+  {
+    service: 'netflix',
+    senderMatch: /@account\.netflix\.com$|@mailer\.netflix\.com$/i,
+    codeRegex: /\b(\d{4})\b/,
+    subjectBlocklist: /household|update.*household|primary.*location/i,
+    validForMinutes: 15,
+  },
+  {
+    service: 'disney',
+    senderMatch: /@disneyplus\.com$|@mail\.disneyplus\.com$/i,
+    codeRegex: /\b(\d{6})\b/,
+    validForMinutes: 15,
+  },
+  {
+    service: 'max',
+    senderMatch: /@(hbomax|max)\.com$|@service\.hbomax\.com$/i,
+    codeRegex: /\b(\d{6})\b/,
+    validForMinutes: 15,
+  },
+  {
+    service: 'amazon',
+    senderMatch: /@amazon\.com$/i,
+    codeRegex: /\b(\d{6})\b/,
+    bodyRequire: /prime video/i,
+    validForMinutes: 15,
+  },
+];
+
+/**
+ * Extract the bare email address from a `from` field.
+ *
+ * Handles both `"Netflix <info@account.netflix.com>"` and bare
+ * `info@account.netflix.com` forms. Returns the address lowercased.
+ */
+function normalizeFrom(from: string): string {
+  const angleMatch = from.match(/<([^>]+)>/);
+  const addr = angleMatch ? angleMatch[1] : from;
+  return addr.trim().toLowerCase();
+}
+
+/**
+ * Select the body content to scan. Prefer plain text when present; fall
+ * back to HTML otherwise. We intentionally do NOT concatenate the two to
+ * avoid duplicate-match noise.
+ */
+function selectBody(parsed: ParsedEmail): string {
+  if (parsed.text && parsed.text.length > 0) return parsed.text;
+  return parsed.html ?? '';
+}
+
+/**
+ * Main dispatcher. Iterates PATTERNS in order and returns the first pattern
+ * that both addresses-matches and successfully extracts a code or link. If a
+ * pattern matches by sender but fails to extract, iteration continues — the
+ * next pattern may cover the same sender (e.g. netflix vs netflix-household).
+ */
+export function matchEmail(parsed: ParsedEmail): MatchResult | null {
+  const from = normalizeFrom(parsed.from);
+  const subject = parsed.subject ?? '';
+  const body = selectBody(parsed);
+
+  for (const pattern of PATTERNS) {
+    if (!pattern.senderMatch.test(from)) continue;
+    if (pattern.subjectBlocklist && pattern.subjectBlocklist.test(subject)) continue;
+    if (pattern.bodyRequire && !pattern.bodyRequire.test(body)) continue;
+
+    if (pattern.codeRegex) {
+      const match = body.match(pattern.codeRegex);
+      if (match) {
+        const value = match[1] ?? match[0];
+        return {
+          service: pattern.service,
+          type: 'code',
+          value,
+          validForMinutes: pattern.validForMinutes,
+        };
+      }
+      continue;
+    }
+
+    if (pattern.linkRegex) {
+      const match = body.match(pattern.linkRegex);
+      if (match) {
+        const value = match[1] ?? match[0];
+        return {
+          service: pattern.service,
+          type: 'household',
+          value,
+          validForMinutes: pattern.validForMinutes,
+        };
+      }
+      continue;
+    }
+  }
+
+  return null;
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -83,12 +83,13 @@ function normalizeFrom(from: string): string {
 }
 
 /**
- * Select the body content to scan. Prefer plain text when present; fall
- * back to HTML otherwise. We intentionally do NOT concatenate the two to
- * avoid duplicate-match noise.
+ * Select the body content to scan. Prefer plain text when non-empty (after
+ * trimming), else fall back to HTML. Some MIME senders include a stub text
+ * part containing only whitespace alongside the real HTML — treat those as
+ * empty so the HTML body is scanned instead.
  */
 function selectBody(parsed: ParsedEmail): string {
-  if (parsed.text && parsed.text.length > 0) return parsed.text;
+  if (parsed.text && parsed.text.trim().length > 0) return parsed.text;
   return parsed.html ?? '';
 }
 
@@ -133,7 +134,6 @@ export function matchEmail(parsed: ParsedEmail): MatchResult | null {
           validForMinutes: pattern.validForMinutes,
         };
       }
-      continue;
     }
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -10,18 +10,23 @@
 
 export type ServiceKey = 'netflix' | 'netflix-household' | 'disney' | 'max' | 'amazon';
 
-export interface Pattern {
+interface PatternCommon {
   service: ServiceKey;
   senderMatch: RegExp;
-  // Exactly one of codeRegex or linkRegex must be set on any given pattern.
-  codeRegex?: RegExp;
-  linkRegex?: RegExp;
   // Skip this pattern if the subject matches.
   subjectBlocklist?: RegExp;
   // Skip this pattern if the body does NOT match.
   bodyRequire?: RegExp;
   validForMinutes: number;
 }
+
+export type CodePattern = PatternCommon & { codeRegex: RegExp; linkRegex?: never };
+export type LinkPattern = PatternCommon & { linkRegex: RegExp; codeRegex?: never };
+
+// Discriminated so TypeScript enforces the "exactly one of codeRegex /
+// linkRegex" invariant at the type level — illegal combinations won't
+// compile, and matchEmail's branches are exhaustive.
+export type Pattern = CodePattern | LinkPattern;
 
 export interface ParsedEmail {
   from: string;
@@ -34,10 +39,25 @@ export type MatchResult =
   | { service: ServiceKey; type: 'code'; value: string; validForMinutes: number }
   | { service: ServiceKey; type: 'household'; value: string; validForMinutes: number };
 
+// Shared fragment used to find a verification code inside the body. The
+// code must be preceded by a recognized contextual word (English or
+// Spanish, since this user's family emails mix languages) so that
+// incidental 4- or 6-digit sequences like copyright years, postal codes,
+// or order numbers don't false-match. `[^\d]{0,40}` allows up to 40 non-
+// digit chars between the keyword and the digits to accommodate typical
+// email phrasing ("Your sign-in code is 1234", "código de verificación: 1234").
+const CODE_CONTEXT = /(?:code|passcode|pin|verification|c[óo]digo|clave|verificaci[óo]n)[^\d]{0,40}/i;
+
+function codeOf(digits: 4 | 6): RegExp {
+  return new RegExp(`${CODE_CONTEXT.source}(\\d{${digits}})\\b`, 'i');
+}
+
 export const PATTERNS: readonly Pattern[] = [
   {
     service: 'netflix-household',
     senderMatch: /@account\.netflix\.com$|@mailer\.netflix\.com$/i,
+    // No capture group on purpose — household extraction returns the full
+    // URL, which matchEmail reads via `match[0]`.
     linkRegex:
       /https:\/\/(?:www\.)?netflix\.com\/account\/(?:travel|update-primary-location)\/[A-Za-z0-9_\-=?&%./]+/,
     validForMinutes: 15,
@@ -45,26 +65,29 @@ export const PATTERNS: readonly Pattern[] = [
   {
     service: 'netflix',
     senderMatch: /@account\.netflix\.com$|@mailer\.netflix\.com$/i,
-    codeRegex: /\b(\d{4})\b/,
+    codeRegex: codeOf(4),
     subjectBlocklist: /household|update.*household|primary.*location/i,
     validForMinutes: 15,
   },
   {
     service: 'disney',
     senderMatch: /@disneyplus\.com$|@mail\.disneyplus\.com$/i,
-    codeRegex: /\b(\d{6})\b/,
+    codeRegex: codeOf(6),
     validForMinutes: 15,
   },
   {
     service: 'max',
+    // `@service.hbomax.com` is a legacy sender from before the HBO Max →
+    // Max rebrand; keeping it broadens backward-compat with any still-
+    // live transactional mail flows until we have real post-rebrand samples.
     senderMatch: /@(hbomax|max)\.com$|@service\.hbomax\.com$/i,
-    codeRegex: /\b(\d{6})\b/,
+    codeRegex: codeOf(6),
     validForMinutes: 15,
   },
   {
     service: 'amazon',
     senderMatch: /@amazon\.com$/i,
-    codeRegex: /\b(\d{6})\b/,
+    codeRegex: codeOf(6),
     bodyRequire: /prime video/i,
     validForMinutes: 15,
   },
@@ -74,12 +97,24 @@ export const PATTERNS: readonly Pattern[] = [
  * Extract the bare email address from a `from` field.
  *
  * Handles both `"Netflix <info@account.netflix.com>"` and bare
- * `info@account.netflix.com` forms. Returns the address lowercased.
+ * `info@account.netflix.com` forms, and lowercases the result.
+ *
+ * Display-name spoofing guard: if the display name (text before the `<`)
+ * itself contains `@`, the value is ambiguous — something like
+ * `"evil@attacker.com <legit@account.netflix.com>"` — and we reject it by
+ * returning the empty string. `senderMatch` against an empty string
+ * never matches, so ambiguous From headers drop.
  */
 function normalizeFrom(from: string): string {
-  const angleMatch = from.match(/<([^>]+)>/);
-  const addr = angleMatch ? angleMatch[1] : from;
-  return addr.trim().toLowerCase();
+  const angleIdx = from.indexOf('<');
+  if (angleIdx !== -1) {
+    const angleMatch = from.match(/<([^>]+)>/);
+    if (!angleMatch) return '';
+    const displayName = from.slice(0, angleIdx).trim().replace(/^"|"$/g, '');
+    if (displayName.includes('@')) return '';
+    return angleMatch[1].trim().toLowerCase();
+  }
+  return from.trim().toLowerCase();
 }
 
 /**

--- a/test/fixtures/amazon-login-non-prime.eml
+++ b/test/fixtures/amazon-login-non-prime.eml
@@ -1,0 +1,39 @@
+From: Amazon <account-update@amazon.com>
+To: codes@example.com
+Subject: Your Amazon sign-in OTP
+Date: Sat, 19 Apr 2026 16:05:12 +0000
+Message-ID: <amazon-login-001@amazon.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="boundary-amazon-login"
+
+--boundary-amazon-login
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+Hi,
+
+Someone is trying to sign in to your Amazon account on a new device.
+Use the one-time passcode below to complete sign-in.
+
+456789
+
+This passcode expires in 15 minutes. If you didn't request this, please
+change your Amazon password immediately.
+
+Thanks,
+Amazon
+
+--boundary-amazon-login
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+<html><body>
+<p>Hi,</p>
+<p>Someone is trying to sign in to your Amazon account on a new device.
+Use the one-time passcode below to complete sign-in.</p>
+<p style="font-size:28px;letter-spacing:6px;">456789</p>
+<p>This passcode expires in 15 minutes. If you didn't request this, please change your Amazon password immediately.</p>
+<p>Thanks,<br>Amazon</p>
+</body></html>
+
+--boundary-amazon-login--

--- a/test/fixtures/amazon-primevideo.eml
+++ b/test/fixtures/amazon-primevideo.eml
@@ -1,0 +1,40 @@
+From: Amazon <no-reply@amazon.com>
+To: codes@example.com
+Subject: Amazon Prime Video: Your sign-in OTP
+Date: Sat, 19 Apr 2026 15:30:44 +0000
+Message-ID: <amazon-primevideo-001@amazon.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="boundary-amazon-primevideo"
+
+--boundary-amazon-primevideo
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+Hi,
+
+You're trying to sign in to Prime Video on a new device.
+
+Your Prime Video one-time passcode is:
+
+345678
+
+This passcode expires in 15 minutes. If you didn't request this, please
+ignore this email.
+
+Thanks,
+Amazon
+
+--boundary-amazon-primevideo
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+<html><body>
+<p>Hi,</p>
+<p>You're trying to sign in to Prime Video on a new device.</p>
+<p>Your Prime Video one-time passcode is:</p>
+<p style="font-size:28px;letter-spacing:6px;">345678</p>
+<p>This passcode expires in 15 minutes. If you didn't request this, please ignore this email.</p>
+<p>Thanks,<br>Amazon</p>
+</body></html>
+
+--boundary-amazon-primevideo--

--- a/test/fixtures/disney-signin.eml
+++ b/test/fixtures/disney-signin.eml
@@ -1,0 +1,40 @@
+From: Disney+ <noreply@disneyplus.com>
+To: codes@example.com
+Subject: Your Disney+ one-time passcode
+Date: Sat, 19 Apr 2026 13:05:17 +0000
+Message-ID: <disney-signin-001@disneyplus.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="boundary-disney-signin"
+
+--boundary-disney-signin
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+Hi there,
+
+Your Disney+ one-time passcode is:
+
+123456
+
+Please enter this code in the Disney+ app or site within the next 15
+minutes.
+
+If you didn't request this, you can safely ignore this email.
+
+Thanks,
+The Disney+ team
+
+--boundary-disney-signin
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+<html><body>
+<p>Hi there,</p>
+<p>Your Disney+ one-time passcode is:</p>
+<p style="font-size:28px;letter-spacing:6px;">123456</p>
+<p>Please enter this code in the Disney+ app or site within the next 15 minutes.</p>
+<p>If you didn't request this, you can safely ignore this email.</p>
+<p>Thanks,<br>The Disney+ team</p>
+</body></html>
+
+--boundary-disney-signin--

--- a/test/fixtures/max-signin.eml
+++ b/test/fixtures/max-signin.eml
@@ -1,0 +1,36 @@
+From: Max <noreply@max.com>
+To: codes@example.com
+Subject: Your Max verification code
+Date: Sat, 19 Apr 2026 14:12:03 +0000
+Message-ID: <max-signin-001@max.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="boundary-max-signin"
+
+--boundary-max-signin
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+Hello,
+
+Use the verification code below to finish signing in to Max:
+
+234567
+
+This code is valid for 15 minutes.
+
+Thanks,
+The Max team
+
+--boundary-max-signin
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+<html><body>
+<p>Hello,</p>
+<p>Use the verification code below to finish signing in to Max:</p>
+<p style="font-size:28px;letter-spacing:6px;">234567</p>
+<p>This code is valid for 15 minutes.</p>
+<p>Thanks,<br>The Max team</p>
+</body></html>
+
+--boundary-max-signin--

--- a/test/fixtures/netflix-household.eml
+++ b/test/fixtures/netflix-household.eml
@@ -1,0 +1,41 @@
+From: Netflix <info@account.netflix.com>
+To: codes@example.com
+Subject: Update your Netflix Household
+Date: Sat, 19 Apr 2026 11:02:41 +0000
+Message-ID: <netflix-household-001@account.netflix.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="boundary-netflix-household"
+
+--boundary-netflix-household
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+Hi user,
+
+It looks like you're watching Netflix from a device that isn't part of
+your Netflix Household. To keep watching, confirm this device belongs to
+your Household.
+
+Confirm device:
+https://www.netflix.com/account/update-primary-location/FAKE_HOUSEHOLD_TOKEN_0001
+
+This link expires in 15 minutes.
+
+Thanks,
+The Netflix team
+
+--boundary-netflix-household
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+<html><body>
+<p>Hi user,</p>
+<p>It looks like you're watching Netflix from a device that isn't part
+of your Netflix Household. To keep watching, confirm this device belongs
+to your Household.</p>
+<p><a href="https://www.netflix.com/account/update-primary-location/FAKE_HOUSEHOLD_TOKEN_0001">Confirm device</a></p>
+<p>This link expires in 15 minutes.</p>
+<p>Thanks,<br>The Netflix team</p>
+</body></html>
+
+--boundary-netflix-household--

--- a/test/fixtures/netflix-signin.eml
+++ b/test/fixtures/netflix-signin.eml
@@ -1,0 +1,39 @@
+From: Netflix <info@account.netflix.com>
+To: codes@example.com
+Subject: Your Netflix sign-in code
+Date: Sat, 19 Apr 2026 10:15:22 +0000
+Message-ID: <netflix-signin-001@account.netflix.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="boundary-netflix-signin"
+
+--boundary-netflix-signin
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+Hi user,
+
+Enter this code to sign in to Netflix:
+
+1234
+
+This code expires in 15 minutes.
+
+If you didn't request this, you can ignore this email.
+
+Thanks,
+The Netflix team
+
+--boundary-netflix-signin
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+<html><body>
+<p>Hi user,</p>
+<p>Enter this code to sign in to Netflix:</p>
+<p style="font-size:32px;font-weight:bold;">1234</p>
+<p>This code expires in 15 minutes.</p>
+<p>If you didn't request this, you can ignore this email.</p>
+<p>Thanks,<br>The Netflix team</p>
+</body></html>
+
+--boundary-netflix-signin--

--- a/test/fixtures/netflix-travel.eml
+++ b/test/fixtures/netflix-travel.eml
@@ -1,0 +1,39 @@
+From: Netflix <info@account.netflix.com>
+To: codes@example.com
+Subject: Your Netflix temporary access code
+Date: Sat, 19 Apr 2026 12:20:05 +0000
+Message-ID: <netflix-travel-001@account.netflix.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="boundary-netflix-travel"
+
+--boundary-netflix-travel
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+Hi user,
+
+Travelling? Get temporary access to Netflix from this device by verifying
+with the account owner.
+
+Get code:
+https://www.netflix.com/account/travel/FAKE_TRAVEL_TOKEN_0002
+
+This link expires in 15 minutes.
+
+Thanks,
+The Netflix team
+
+--boundary-netflix-travel
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+<html><body>
+<p>Hi user,</p>
+<p>Travelling? Get temporary access to Netflix from this device by
+verifying with the account owner.</p>
+<p><a href="https://www.netflix.com/account/travel/FAKE_TRAVEL_TOKEN_0002">Get code</a></p>
+<p>This link expires in 15 minutes.</p>
+<p>Thanks,<br>The Netflix team</p>
+</body></html>
+
+--boundary-netflix-travel--

--- a/test/fixtures/random-newsletter.eml
+++ b/test/fixtures/random-newsletter.eml
@@ -1,0 +1,46 @@
+From: Weekly Digest <newsletter@example.org>
+To: codes@example.com
+Subject: This week in tech: issue #524312
+Date: Sat, 19 Apr 2026 17:00:00 +0000
+Message-ID: <newsletter-524312@example.org>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="boundary-newsletter"
+
+--boundary-newsletter
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+Hello subscriber,
+
+Welcome to issue #524312 of the Weekly Digest. Here's what caught our
+eye this week:
+
+- Cloudflare announced 678901 new POPs (not really).
+- TypeScript 5.9 hits stable.
+- A new open-source email parser for Workers.
+
+If you no longer wish to receive these emails, you can unsubscribe at
+any time using the link at the bottom.
+
+Thanks for reading!
+The Weekly Digest team
+
+--boundary-newsletter
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: 7bit
+
+<html><body>
+<p>Hello subscriber,</p>
+<p>Welcome to issue #524312 of the Weekly Digest. Here's what caught
+our eye this week:</p>
+<ul>
+<li>Cloudflare announced 678901 new POPs (not really).</li>
+<li>TypeScript 5.9 hits stable.</li>
+<li>A new open-source email parser for Workers.</li>
+</ul>
+<p>If you no longer wish to receive these emails, you can unsubscribe at
+any time using the link at the bottom.</p>
+<p>Thanks for reading!<br>The Weekly Digest team</p>
+</body></html>
+
+--boundary-newsletter--

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -228,6 +228,83 @@ describe('matchEmail — direct unit tests (branch coverage)', () => {
     expect(result).toBeNull();
   });
 
+  it('rejects display-name spoofing (address-shaped display name with a legit angle-bracket address)', () => {
+    // SECURITY: "Evil Display <legit@...>" must NOT authenticate as the
+    // legit sender. An @ in the display name is treated as ambiguous and
+    // normalizeFrom returns empty, so senderMatch fails for every pattern.
+    const parsed: ParsedEmail = {
+      from: 'evil@attacker.example <info@account.netflix.com>',
+      subject: 'Your Netflix sign-in code',
+      text: 'Your code is 1234.',
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toBeNull();
+  });
+
+  it('rejects a malformed from with an unclosed angle bracket', () => {
+    const parsed: ParsedEmail = {
+      from: 'Netflix <info@account.netflix.com',
+      subject: 'Your Netflix sign-in code',
+      text: 'Your code is 1234.',
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toBeNull();
+  });
+
+  it('extracts the Netflix code from context and ignores nearby 4-digit years', () => {
+    // A real Netflix email may include "© 2026 Netflix, Inc." or
+    // "account since 2019". The codeRegex requires a contextual word
+    // (code/passcode/código/...) so the year-shaped digits are skipped.
+    const parsed: ParsedEmail = {
+      from: 'info@account.netflix.com',
+      subject: 'Your Netflix sign-in code',
+      text: 'Account since 2019. Your sign-in code is 7531. © 2026 Netflix, Inc.',
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toEqual({
+      service: 'netflix',
+      type: 'code',
+      value: '7531',
+      validForMinutes: 15,
+    });
+  });
+
+  it('extracts a Spanish-language code via "código"', () => {
+    const parsed: ParsedEmail = {
+      from: 'info@account.netflix.com',
+      subject: 'Tu código de inicio de sesión de Netflix',
+      text: 'Tu código de verificación es 4242. Expira en 15 minutos.',
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toEqual({
+      service: 'netflix',
+      type: 'code',
+      value: '4242',
+      validForMinutes: 15,
+    });
+  });
+
+  it('matches a Netflix household link when it only appears in the HTML body', () => {
+    const parsed: ParsedEmail = {
+      from: 'info@account.netflix.com',
+      subject: 'Update your Netflix Household',
+      text: '',
+      html:
+        '<p><a href="https://www.netflix.com/account/update-primary-location/' +
+        'HTML_ONLY_TOKEN_0002">Confirm</a></p>',
+    };
+    const result = matchEmail(parsed);
+    expect(result?.service).toBe('netflix-household');
+    expect(result?.type).toBe('household');
+    expect(result?.value).toContain(
+      'https://www.netflix.com/account/update-primary-location/HTML_ONLY_TOKEN_0002',
+    );
+  });
+
   it('returns null when Amazon sender matches but body lacks Prime Video', () => {
     const parsed: ParsedEmail = {
       from: 'no-reply@amazon.com',

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,0 +1,293 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import PostalMime from 'postal-mime';
+import { describe, expect, it, test } from 'vitest';
+
+import { matchEmail, PATTERNS, type ParsedEmail } from '../src/parser';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function loadFixture(name: string): Promise<ParsedEmail> {
+  const raw = readFileSync(join(__dirname, 'fixtures', name), 'utf8');
+  const parsed = await PostalMime.parse(raw);
+  return {
+    from: parsed.from?.address ?? '',
+    subject: parsed.subject ?? '',
+    text: parsed.text ?? '',
+    html: parsed.html ?? '',
+  };
+}
+
+describe('matchEmail — happy paths per service', () => {
+  it('matches a Netflix sign-in code', async () => {
+    const parsed = await loadFixture('netflix-signin.eml');
+    const result = matchEmail(parsed);
+    expect(result).toEqual({
+      service: 'netflix',
+      type: 'code',
+      value: '1234',
+      validForMinutes: 15,
+    });
+  });
+
+  it('matches a Disney+ sign-in code', async () => {
+    const parsed = await loadFixture('disney-signin.eml');
+    const result = matchEmail(parsed);
+    expect(result).toEqual({
+      service: 'disney',
+      type: 'code',
+      value: '123456',
+      validForMinutes: 15,
+    });
+  });
+
+  it('matches a Max sign-in code', async () => {
+    const parsed = await loadFixture('max-signin.eml');
+    const result = matchEmail(parsed);
+    expect(result).toEqual({
+      service: 'max',
+      type: 'code',
+      value: '234567',
+      validForMinutes: 15,
+    });
+  });
+
+  it('matches an Amazon Prime Video code when body references Prime Video', async () => {
+    const parsed = await loadFixture('amazon-primevideo.eml');
+    const result = matchEmail(parsed);
+    expect(result).toEqual({
+      service: 'amazon',
+      type: 'code',
+      value: '345678',
+      validForMinutes: 15,
+    });
+  });
+});
+
+describe('matchEmail — Netflix household / travel', () => {
+  it('matches a Netflix household email as household (not as a 4-digit code)', async () => {
+    const parsed = await loadFixture('netflix-household.eml');
+    const result = matchEmail(parsed);
+    expect(result?.service).toBe('netflix-household');
+    expect(result?.type).toBe('household');
+    expect(result?.value).toContain(
+      'https://www.netflix.com/account/update-primary-location/',
+    );
+    expect(result?.validForMinutes).toBe(15);
+  });
+
+  it('matches a Netflix travel email as household (travel link family)', async () => {
+    const parsed = await loadFixture('netflix-travel.eml');
+    const result = matchEmail(parsed);
+    expect(result?.service).toBe('netflix-household');
+    expect(result?.type).toBe('household');
+    expect(result?.value).toContain('https://www.netflix.com/account/travel/');
+  });
+});
+
+describe('matchEmail — negative cases', () => {
+  it('returns null for an Amazon non-Prime-Video login email (bodyRequire rejects)', async () => {
+    const parsed = await loadFixture('amazon-login-non-prime.eml');
+    const result = matchEmail(parsed);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for an unrelated newsletter', async () => {
+    const parsed = await loadFixture('random-newsletter.eml');
+    const result = matchEmail(parsed);
+    expect(result).toBeNull();
+  });
+});
+
+describe('matchEmail — direct unit tests (branch coverage)', () => {
+  it('handles a bare (un-wrapped) from address', () => {
+    const parsed: ParsedEmail = {
+      from: 'info@account.netflix.com',
+      subject: 'Your Netflix sign-in code',
+      text: 'Your code is 4242. It expires in 15 minutes.',
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toEqual({
+      service: 'netflix',
+      type: 'code',
+      value: '4242',
+      validForMinutes: 15,
+    });
+  });
+
+  it('handles a from address with display name and uppercase characters', () => {
+    const parsed: ParsedEmail = {
+      from: 'Netflix <INFO@Account.Netflix.COM>',
+      subject: 'Your Netflix sign-in code',
+      text: 'Code: 9999',
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toEqual({
+      service: 'netflix',
+      type: 'code',
+      value: '9999',
+      validForMinutes: 15,
+    });
+  });
+
+  it('falls back to HTML body when text body is empty', () => {
+    const parsed: ParsedEmail = {
+      from: 'noreply@disneyplus.com',
+      subject: 'Your code',
+      text: '',
+      html: '<p>Code: <b>777777</b></p>',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toEqual({
+      service: 'disney',
+      type: 'code',
+      value: '777777',
+      validForMinutes: 15,
+    });
+  });
+
+  it('returns null when body is empty and no pattern can extract', () => {
+    const parsed: ParsedEmail = {
+      from: 'noreply@disneyplus.com',
+      subject: 'empty',
+      text: '',
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toBeNull();
+  });
+
+  it('skips the plain-netflix pattern when subject mentions "household" and body has no household link, yielding null', () => {
+    // Sender matches Netflix. Subject has "household" so plain netflix is
+    // skipped by subjectBlocklist. netflix-household ran first but its
+    // linkRegex finds no link in the body. Result: null — a "sender hit
+    // but no extraction" case across BOTH netflix patterns.
+    const parsed: ParsedEmail = {
+      from: 'info@account.netflix.com',
+      subject: 'Your Netflix Household update',
+      text: 'Nothing useful here and no link.',
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toBeNull();
+  });
+
+  it('continues to the next pattern when an earlier pattern matches sender but fails to extract', () => {
+    // Sender matches netflix-household's senderMatch, but there's no link
+    // in the body. Implementation must NOT give up — it should continue
+    // and let the plain-netflix pattern succeed on the 4-digit code.
+    const parsed: ParsedEmail = {
+      from: 'info@account.netflix.com',
+      subject: 'Your Netflix sign-in code',
+      text: 'Your code is 5678.',
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toEqual({
+      service: 'netflix',
+      type: 'code',
+      value: '5678',
+      validForMinutes: 15,
+    });
+  });
+
+  it('returns null when subject field is undefined-shaped (empty string)', () => {
+    const parsed: ParsedEmail = {
+      from: 'random@unknown.example',
+      subject: '',
+      text: 'nothing',
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when from is empty string', () => {
+    const parsed: ParsedEmail = {
+      from: '',
+      subject: 'Your code',
+      text: '123456',
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when Max pattern sender matches but no 6-digit code is present', () => {
+    const parsed: ParsedEmail = {
+      from: 'noreply@max.com',
+      subject: 'Welcome',
+      text: 'Thanks for joining Max!',
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when Amazon sender matches but body lacks Prime Video', () => {
+    const parsed: ParsedEmail = {
+      from: 'no-reply@amazon.com',
+      subject: 'Your Amazon code',
+      text: 'Your code is 222222.',
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toBeNull();
+  });
+});
+
+describe('matchEmail — defensive branches', () => {
+  it('uses match[0] when the subject is missing entirely (undefined)', () => {
+    // Covers the `parsed.subject ?? ''` fallback branch where subject is
+    // not provided. The ParsedEmail type requires `subject`, but in
+    // practice a postal-mime Email can have subject undefined; we cast
+    // here to exercise the defensive branch without polluting the type.
+    const parsed = {
+      from: 'noreply@disneyplus.com',
+      // subject omitted
+      text: 'Your code is 424242',
+      html: '',
+    } as unknown as ParsedEmail;
+    const result = matchEmail(parsed);
+    expect(result).toEqual({
+      service: 'disney',
+      type: 'code',
+      value: '424242',
+      validForMinutes: 15,
+    });
+  });
+
+  it('falls back to empty string when html is missing and text is absent', () => {
+    // Covers the `parsed.html ?? ''` branch in selectBody.
+    const parsed = {
+      from: 'noreply@disneyplus.com',
+      subject: 'no body at all',
+      text: '',
+      // html omitted
+    } as unknown as ParsedEmail;
+    const result = matchEmail(parsed);
+    expect(result).toBeNull();
+  });
+});
+
+describe('PATTERNS invariants', () => {
+  test('each pattern has exactly one of codeRegex or linkRegex', () => {
+    for (const pattern of PATTERNS) {
+      const hasCode = Boolean(pattern.codeRegex);
+      const hasLink = Boolean(pattern.linkRegex);
+      expect(hasCode !== hasLink).toBe(true);
+    }
+  });
+
+  test('netflix-household is ordered before netflix', () => {
+    const householdIdx = PATTERNS.findIndex((p) => p.service === 'netflix-household');
+    const netflixIdx = PATTERNS.findIndex((p) => p.service === 'netflix');
+    expect(householdIdx).toBeGreaterThanOrEqual(0);
+    expect(netflixIdx).toBeGreaterThanOrEqual(0);
+    expect(householdIdx).toBeLessThan(netflixIdx);
+  });
+});

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -195,7 +195,7 @@ describe('matchEmail — direct unit tests (branch coverage)', () => {
     });
   });
 
-  it('returns null when subject field is undefined-shaped (empty string)', () => {
+  it('returns null when the sender matches no pattern', () => {
     const parsed: ParsedEmail = {
       from: 'random@unknown.example',
       subject: '',
@@ -271,6 +271,24 @@ describe('matchEmail — defensive branches', () => {
     } as unknown as ParsedEmail;
     const result = matchEmail(parsed);
     expect(result).toBeNull();
+  });
+
+  it('falls back to HTML when the text part is only whitespace', () => {
+    // Some MIME senders include a whitespace-only stub text part alongside
+    // the real HTML body. selectBody should skip the whitespace stub.
+    const parsed: ParsedEmail = {
+      from: 'noreply@disneyplus.com',
+      subject: 'Your Disney+ sign-in code',
+      text: '   \n\n  \t  ',
+      html: '<p>Your verification code is <strong>557788</strong>.</p>',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toEqual({
+      service: 'disney',
+      type: 'code',
+      value: '557788',
+      validForMinutes: 15,
+    });
   });
 });
 

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,7 +1,0 @@
-// Trivial smoke test to validate the CI pipeline on an empty scaffold.
-// This file will be removed in the Parser PR once real tests exist.
-import { test, expect } from 'vitest';
-
-test('scaffold compiles', () => {
-  expect(true).toBe(true);
-});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
-    "types": ["@cloudflare/workers-types", "vitest/globals", "node"],
+    "types": ["@cloudflare/workers-types"],
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,
@@ -13,5 +13,5 @@
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
-    "types": ["@cloudflare/workers-types", "vitest/globals"],
+    "types": ["@cloudflare/workers-types", "vitest/globals", "node"],
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types", "vitest/globals", "node"]
+  },
+  "include": ["src/**/*", "test/**/*"]
+}


### PR DESCRIPTION
## Summary

- Implements `src/parser.ts` with `PATTERNS` (netflix-household first, then netflix, disney, max, amazon), typed interfaces, and the `matchEmail()` dispatcher that iterates patterns in order and returns the first sender-matching pattern that extracts a code or link.
- Adds sanitized `.eml` fixtures per service (happy paths + household/travel + amazon body-require negative + unrelated-sender negative) with fake addresses and synthetic codes.
- Adds `test/parser.test.ts` (22 tests) achieving 100% line coverage of `src/parser.ts`.

## Notes

- Pattern order change vs the original build spec: \`netflix-household\` is now listed **before** \`netflix\` so household emails match the household pattern explicitly rather than relying on the sign-in pattern's subject blocklist. The blocklist is kept as a belt-and-suspenders guard.
- \`@types/node\` added so tests can use \`fs\`/\`path\`. Runtime Worker code does not import from \`node:*\`; CF Workers types remain the authoritative lib.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 22/22 passing
- [x] \`npm run test:coverage\` — 100% line coverage on \`src/parser.ts\`
- [x] Fixtures contain no personal data (all \`example.com\`, synthetic codes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)