### PR TITLE
chore: deployment config (KV id + TRUSTED_FORWARDER)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,6 @@
+# Local values for `wrangler dev`. Copy this file to `.dev.vars` (which is
+# gitignored via .gitignore) and fill in a value. In production, the real
+# TRUSTED_FORWARDER is set out of band via `wrangler secret put` — see
+# README §4 step 5. Without this file set, `wrangler dev` will reject
+# every incoming mail with "skip: forwarder verification failed".
+TRUSTED_FORWARDER="test@example.com"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules/
 .wrangler/
 .env
 .env.local
+# Local-only values for `wrangler dev`; the committed template is
+# .dev.vars.example. Never commit real secrets here.
+.dev.vars
 dist/
 coverage/
 *.log

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ No home server. No Docker. All compute runs on Cloudflare's edge.
    The CLI prints an `id = "..."` line. Open `wrangler.toml` and replace `REPLACE_WITH_KV_NAMESPACE_ID` with that id.
 
 3. **Set personal values in `wrangler.toml`:**
-   - `TRUSTED_FORWARDER` — your Gmail address. This is the **only** sender the Worker will accept mail from; everything else is dropped.
    - `TIMEZONE` — your IANA timezone. `America/Santiago` ships as the default — change it to your own (e.g. `America/New_York`, `Europe/Madrid`).
    - `DASHBOARD_TITLE` — whatever you want at the top of the page (e.g. `"Family Codes"`).
    - `FOOTER_TEXT` — optional line shown in the page footer. Leave as `""` if you don't want one.
@@ -90,17 +89,23 @@ No home server. No Docker. All compute runs on Cloudflare's edge.
    npx wrangler deploy
    ```
 
-5. **Cloudflare dashboard — Email Routing:**
+5. **Set your trusted forwarder as a Worker secret** (kept out of git so your Gmail address isn't in the commit history):
+   ```bash
+   npx wrangler secret put TRUSTED_FORWARDER
+   ```
+   Paste your Gmail address (e.g. `you@gmail.com`) when prompted. This is the **only** sender the Worker will accept mail from; everything else is dropped. At runtime `env.TRUSTED_FORWARDER` resolves to this value just like a regular `[vars]` entry. If you forget this step, every incoming mail will be rejected and you'll see `skip: forwarder verification failed` in `wrangler tail`.
+
+6. **Cloudflare dashboard — Email Routing:**
    - Go to *your domain → Email → Email Routing*.
    - Enable it if it isn't already (this provisions the required MX records).
-   - Create a custom address `codes@<yourdomain>` that forwards to **your personal inbox** *temporarily*. This is only so the Gmail verification email in step 6 arrives somewhere you can read it. You'll change this destination in step 8.
+   - Create a custom address `codes@<yourdomain>` that forwards to **your personal inbox** *temporarily*. This is only so the Gmail verification email in step 7 arrives somewhere you can read it. You'll change this destination in step 9.
 
-6. **Gmail — register the forwarding address:**
+7. **Gmail — register the forwarding address:**
    - Gmail → *Settings → Forwarding and POP/IMAP* → *Add a forwarding address* → enter `codes@<yourdomain>`.
-   - Gmail sends a verification code to that address. Cloudflare Email Routing forwards it to your inbox (per step 5). Copy the code and paste it back into Gmail.
-   - Once verified, **do NOT** enable automatic forwarding globally. You'll use a filter (step 7) so only OTP mails get forwarded.
+   - Gmail sends a verification code to that address. Cloudflare Email Routing forwards it to your inbox (per step 6). Copy the code and paste it back into Gmail.
+   - Once verified, **do NOT** enable automatic forwarding globally. You'll use a filter (step 8) so only OTP mails get forwarded.
 
-7. **Gmail — create the forwarding filter:**
+8. **Gmail — create the forwarding filter:**
    - Gmail → *Settings → Filters and Blocked Addresses* → *Create a new filter*.
    - Criteria (From):
      ```
@@ -111,19 +116,19 @@ No home server. No Docker. All compute runs on Cloudflare's edge.
    - **Do NOT check "Skip the Inbox".** You want the original email to stay in your inbox as an audit trail and manual fallback.
    - Save.
 
-8. **Cloudflare dashboard — flip Email Routing to the Worker:**
+9. **Cloudflare dashboard — flip Email Routing to the Worker:**
    - Back in *Email Routing*, edit the `codes@<yourdomain>` route.
    - Change the destination from "Send to email" to "Send to Worker", and pick `otp-please`.
    - Keep (or add) a catch-all `*@<yourdomain>` route pointing at your personal inbox as a safety net.
 
-9. **Cloudflare Access — protect the dashboard:**
-   - *Zero Trust → Access → Applications → Add an application → Self-hosted*.
-   - Application domain: your Worker's hostname (either the default `otp-please.<subdomain>.workers.dev` or a custom `codes.<yourdomain>` if you mapped one).
-   - Identity provider: Google Workspace OAuth is the easiest for a family setup.
-   - Policy: email allowlist containing the family Gmail addresses that should be able to see the dashboard.
-   - **Bypass rule:** path `/healthz` — exempt from auth so uptime monitors (and Cloudflare itself) can probe it without a cookie.
+10. **Cloudflare Access — protect the dashboard:**
+    - *Zero Trust → Access → Applications → Add an application → Self-hosted*.
+    - Application domain: your Worker's hostname (either the default `otp-please.<subdomain>.workers.dev` or a custom `codes.<yourdomain>` if you mapped one).
+    - Identity provider: Google Workspace OAuth is the easiest for a family setup.
+    - Policy: email allowlist containing the family Gmail addresses that should be able to see the dashboard.
+    - **Bypass rule:** path `/healthz` — exempt from auth so uptime monitors (and Cloudflare itself) can probe it without a cookie.
 
-10. **Trigger a test OTP** on one of the configured services (e.g. sign out of Netflix and sign back in). In a terminal, watch the live logs:
+11. **Trigger a test OTP** on one of the configured services (e.g. sign out of Netflix and sign back in). In a terminal, watch the live logs:
     ```bash
     npx wrangler tail
     ```
@@ -135,7 +140,7 @@ No home server. No Docker. All compute runs on Cloudflare's edge.
 2. Add the new service name to `SERVICE_KEYS` at the top of `src/parser.ts`. TypeScript enforces that `ServiceKey` stays in sync.
 3. Add a display-name + Tailwind accent colors to `SERVICE_META` in `src/dashboard.ts`, and add the service to `DISPLAY_ORDER` so the card shows up in the layout.
 4. Drop a sanitized `.eml` fixture into `test/fixtures/` and add a matching test in `test/parser.test.ts`. Fixtures use obviously-fake values like `FAKE_TRAVEL_TOKEN_0002` or sequential digits (`123456`).
-5. Update the Gmail filter in [setup step 7](#setup) to include the new sender address.
+5. Update the Gmail filter in [setup step 8](#setup) to include the new sender address.
 6. `npm test` → `npx wrangler deploy`.
 
 ## Debugging
@@ -153,7 +158,7 @@ npx wrangler kv key get --binding=OTP_STORE entry:netflix
 
 Common failure modes and what they mean:
 
-- **`skip: forwarder verification failed (envelope rejected)`** — the inbound message's `Authentication-Results` header did not contain an `spf=pass` with an `smtp.mailfrom` matching your configured `TRUSTED_FORWARDER`. Usually means the filter is forwarding from a different Gmail account than the one in `wrangler.toml`. Confirm in Gmail's filter settings.
+- **`skip: forwarder verification failed (envelope rejected)`** — the inbound message's `Authentication-Results` header did not contain an `spf=pass` with an `smtp.mailfrom` matching your configured `TRUSTED_FORWARDER`. Either the secret isn't set (run `npx wrangler secret put TRUSTED_FORWARDER`), or the filter is forwarding from a different Gmail account than the one you configured. Confirm in Gmail's filter settings.
 - **`skip: no pattern matched for "..." from ...`** — the sender address or body didn't match any entry in `PATTERNS`. The log includes the subject and parsed `from`; compare them against `src/parser.ts` and adjust the regex if the service has changed its email template.
 - **`err: KV write failed for <service>: ...`** — a transient KV put failure. The Worker does NOT retry on purpose (see the [Security model](#security-model) below) — the next email from the same service will simply overwrite the key. If you see this repeatedly, check Cloudflare status.
 - **Empty dashboard but `wrangler tail` shows stored entries** — either the codes already expired (their `valid_until` + 1 hour grace elapsed), or the KV namespace id in `wrangler.toml` doesn't match the one the dashboard binding reads from. Run `npx wrangler kv key list --binding=OTP_STORE` to confirm what's actually stored.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Common failure modes and what they mean:
 - **`skip: no pattern matched for "..." from ...`** — the sender address or body didn't match any entry in `PATTERNS`. The log includes the subject and parsed `from`; compare them against `src/parser.ts` and adjust the regex if the service has changed its email template.
 - **`err: KV write failed for <service>: ...`** — a transient KV put failure. The Worker does NOT retry on purpose (see the [Security model](#security-model) below) — the next email from the same service will simply overwrite the key. If you see this repeatedly, check Cloudflare status.
 - **Empty dashboard but `wrangler tail` shows stored entries** — either the codes already expired (their `valid_until` + 1 hour grace elapsed), or the KV namespace id in `wrangler.toml` doesn't match the one the dashboard binding reads from. Run `npx wrangler kv key list --binding=OTP_STORE` to confirm what's actually stored.
+- **`wrangler dev` always rejects emails** — Worker secrets are not exposed to `wrangler dev`. Copy `.dev.vars.example` to `.dev.vars` and set `TRUSTED_FORWARDER="..."` to a value `wrangler dev` can feed as an env var. `.dev.vars` is gitignored so it won't land in the repo.
 
 ## Security model
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,19 +4,24 @@ compatibility_date = "2026-04-20"
 
 # KV namespace for storing extracted codes and household links.
 # After running `wrangler kv namespace create OTP_STORE`, paste the returned
-# id here (or leave a placeholder and document the step in the README).
+# id here (or keep the placeholder and document the step in the README).
 [[kv_namespaces]]
 binding = "OTP_STORE"
-id = "REPLACE_WITH_KV_NAMESPACE_ID"
+id = "b46c24c9e4754cffb58be2b94a36dce8"
 
 [vars]
 TIMEZONE = "America/Santiago"
 DASHBOARD_TITLE = "Streaming Codes"
 # Optional cheeky line shown in dashboard footer. Empty = no footer text.
 FOOTER_TEXT = ""
-# The Gmail address that is the only trusted forwarder into this Worker.
-# The email handler accepts mail only if Authentication-Results shows
-# spf=pass with smtp.mailfrom matching this address.
-TRUSTED_FORWARDER = "REPLACE_WITH_YOUR_GMAIL_ADDRESS"
 # P1: hostname resolvable only from the home tailnet. Empty = P0 mode.
 TAILSCALE_PROBE_URL = ""
+
+# TRUSTED_FORWARDER is set OUT OF BAND as a Worker secret, not here, so
+# the deployer's Gmail address never enters git history:
+#   npx wrangler secret put TRUSTED_FORWARDER
+# The Env interface in src/config.ts still declares it as a required
+# string — at runtime a secret shows up on `env` just like a [vars]
+# entry. If TRUSTED_FORWARDER is not set, verifyForwarder rejects every
+# incoming mail and you'll see "skip: forwarder verification failed" in
+# `wrangler tail`.


### PR DESCRIPTION
## Summary

Wires up the two personal-deployment placeholders in \`wrangler.toml\`, but keeps the Gmail address out of git:

- \`kv_namespaces[0].id\` → \`b46c24c9e4754cffb58be2b94a36dce8\` (the newly-created \`otp-please-OTP_STORE\` namespace).
- **\`TRUSTED_FORWARDER\` moved out of \`[vars]\` entirely.** It's now set as a Worker secret via \`wrangler secret put TRUSTED_FORWARDER\` after first deploy. At runtime the secret shows up on \`env\` just like a \`[vars]\` entry, so the \`Env\` interface in \`src/config.ts\` is unchanged and \`verifyForwarder\` reads it exactly the same way.
- README §4 adds an explicit step 5 (\"Set your trusted forwarder as a Worker secret\") between deploy and Email Routing, and the remaining steps renumber. The debug cookbook now covers the missing-secret failure mode.

## Why

\`TRUSTED_FORWARDER\` is a trust-boundary declaration, not a security secret (knowing it doesn't let an attacker pass the SPF check). But it **is** PII — committing a specific Gmail address into a public repo permanently is avoidable, and a previous AI review flagged it. Using a Worker secret keeps the template clean for forks and keeps the deployer's Gmail out of search-indexed git history.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 89/89 pass
- [x] Force-pushed to rewrite history (the first commit on this branch briefly had the Gmail in \`[vars]\`; that commit is now orphaned)
- [ ] AI review
- [ ] Post-merge: \`wrangler deploy\` then \`wrangler secret put TRUSTED_FORWARDER\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)