### PR TITLE
chore: bind Worker to codes.ignaciohermosilla.com custom domain

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,14 @@ name = "otp-please"
 main = "src/index.ts"
 compatibility_date = "2026-04-20"
 
+# Serve the dashboard at a friendly custom domain on the deployer's zone.
+# `custom_domain = true` lets Cloudflare auto-manage the DNS + TLS for
+# this hostname without us pre-creating a proxied CNAME. Point the
+# pattern at whatever subdomain you want family members to bookmark.
+routes = [
+  { pattern = "codes.ignaciohermosilla.com", custom_domain = true },
+]
+
 # KV namespace for storing extracted codes and household links.
 # After running `wrangler kv namespace create OTP_STORE`, paste the returned
 # id here (or keep the placeholder and document the step in the README).


### PR DESCRIPTION
## Summary

Adds a \`routes\` entry to \`wrangler.toml\` so the Worker serves at \`codes.ignaciohermosilla.com\` via Cloudflare's Custom Domains feature (\`custom_domain = true\`). Cloudflare auto-manages the DNS record and SSL cert — no pre-created proxied CNAME needed.

## Why

Prefer a memorable family-facing URL over a \`*.workers.dev\` default. Deployers who fork this repo would change the hostname to match their own zone.

## Test plan

- [x] \`wrangler deploy\` — reports \"codes.ignaciohermosilla.com (custom domain)\" as a trigger
- [x] \`curl https://codes.ignaciohermosilla.com/healthz\` → 200
- [x] \`curl https://codes.ignaciohermosilla.com/\` → 200 HTML with \`<!DOCTYPE html>\`
- [x] \`curl https://codes.ignaciohermosilla.com/api\` → 200 JSON all-null payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)