### PR TITLE
feat: manual forwards + Gmail dot normalization + observability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,12 +91,28 @@ export function verifyForwarder(
 }
 
 /**
- * Lowercase, trim surrounding whitespace, and strip a single layer of
- * angle brackets. Used for smtp.mailfrom values (sometimes `<a@b>`) and
- * the configured TRUSTED_FORWARDER value.
+ * Lowercase, trim surrounding whitespace, strip a single layer of
+ * angle brackets, and — for gmail.com / googlemail.com addresses —
+ * remove dots from the local-part. Used for smtp.mailfrom values
+ * (sometimes `<a@b>`) and the configured TRUSTED_FORWARDER value.
+ *
+ * Gmail dot normalization: Google treats `foo.bar@gmail.com` and
+ * `foobar@gmail.com` as the same mailbox. Outbound SPF stamps the
+ * envelope with whichever canonical form the account uses, which may
+ * differ from the form the deployer configured in TRUSTED_FORWARDER.
+ * Stripping dots on both sides makes the comparison correct for any
+ * variant of a Gmail address.
  */
 function normalizeAddress(value: string): string {
-  return value.trim().replace(/^<|>$/g, '').trim().toLowerCase();
+  const bare = value.trim().replace(/^<|>$/g, '').trim().toLowerCase();
+  const atIdx = bare.lastIndexOf('@');
+  if (atIdx === -1) return bare;
+  const local = bare.slice(0, atIdx);
+  const domain = bare.slice(atIdx + 1);
+  if (domain === 'gmail.com' || domain === 'googlemail.com') {
+    return `${local.replace(/\./g, '')}@${domain}`;
+  }
+  return bare;
 }
 
 export default {

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,12 +146,18 @@ export default {
 
     const match = matchEmail(normalized);
     if (!match) {
-      // Subject and parsed from are safe to log here: we've already
-      // confirmed the message was forwarded by the trusted party, so
-      // parsed.from is the original streaming-service sender (e.g.
-      // info@account.netflix.com), not the forwarder's Gmail address.
+      // Log only the sender DOMAIN, not the full address. With
+      // manual-forward support, the outer `from` on a no-match can
+      // be a family member's personal Gmail (`foo@gmail.com`) —
+      // logging that verbatim would leak PII into Worker logs and
+      // now that observability is enabled, those logs persist. The
+      // domain alone is enough to debug template/regex drift
+      // ("unknown sender from gmail.com" = manual forward, from
+      // account.netflix.com = something changed upstream).
+      const atIdx = normalized.from.lastIndexOf('@');
+      const domain = atIdx === -1 ? 'unknown' : normalized.from.slice(atIdx + 1);
       console.log(
-        `skip: no pattern matched for "${normalized.subject}" from ${normalized.from}`,
+        `skip: no pattern matched for "${normalized.subject}" from @${domain}`,
       );
       return;
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -184,16 +184,74 @@ function selectBody(parsed: ParsedEmail): string {
 }
 
 /**
+ * Extract the sender address from a Gmail-style forwarded-message
+ * block in the body. Gmail's "Forward" button produces a quoted
+ * block like:
+ *
+ *   ---------- Forwarded message ---------
+ *   From: Netflix <info@account.netflix.com>
+ *   Date: ...
+ *   Subject: ...
+ *   To: <original recipient>
+ *
+ * When a family member clicks Forward and sends an OTP email to the
+ * Worker, the outer RFC 822 `From:` becomes *their* Gmail (not the
+ * streaming service). The original sender only survives inside the
+ * quoted header block, which is what this helper pulls out so
+ * matchEmail can still run the real sender through senderMatch.
+ *
+ * Trust model: by the time matchEmail runs, verifyForwarder has
+ * already confirmed the envelope came from the configured
+ * TRUSTED_FORWARDER (the deployer's Gmail). The body is therefore
+ * authored by the trusted forwarder and it's safe to extract the
+ * inner From. A non-trusted sender wouldn't pass the envelope check
+ * in the first place.
+ *
+ * Localization: Gmail localizes the separator — English uses
+ * "Forwarded message", Spanish uses "Mensaje reenviado". Both are
+ * recognized. Returns null if no forwarded block is found.
+ */
+function extractForwardedFrom(body: string): string | null {
+  const fwdMatch = body.match(/-+\s*(?:Forwarded message|Mensaje reenviado)\s*-+/i);
+  if (!fwdMatch || fwdMatch.index === undefined) return null;
+  // Look for "From: ... <addr>" within 500 chars after the marker.
+  const tail = body.slice(fwdMatch.index, fwdMatch.index + 500);
+  const fromMatch = tail.match(/^From:\s*(?:[^<\n]*?<)?([^<>\s\n,]+@[^<>\s\n,]+)/im);
+  return fromMatch ? normalizeFrom(fromMatch[1]) : null;
+}
+
+/**
  * Main dispatcher. Iterates PATTERNS in order and returns the first pattern
  * that both addresses-matches and successfully extracts a code or link. If a
  * pattern matches by sender but fails to extract, iteration continues so the
  * caller can fall through to a later pattern covering the same sender.
+ *
+ * Manual-forward support: if the outer `from` doesn't match any
+ * pattern, try again using the inner `From:` pulled from a Gmail-
+ * style forwarded-message block in the body. This lets a family
+ * member hit Gmail's Forward button on an OTP and still have the
+ * Worker recognize it.
  */
 export function matchEmail(parsed: ParsedEmail): MatchResult | null {
-  const from = normalizeFrom(parsed.from);
+  const outerFrom = normalizeFrom(parsed.from);
   const subject = parsed.subject ?? '';
   const body = selectBody(parsed);
 
+  const primary = tryMatch(outerFrom, subject, body);
+  if (primary) return primary;
+
+  const innerFrom = extractForwardedFrom(body);
+  if (innerFrom && innerFrom !== outerFrom) {
+    return tryMatch(innerFrom, subject, body);
+  }
+  return null;
+}
+
+function tryMatch(
+  from: string,
+  subject: string,
+  body: string,
+): MatchResult | null {
   for (const pattern of PATTERNS) {
     if (!pattern.senderMatch.test(from)) continue;
     if (pattern.subjectBlocklist && pattern.subjectBlocklist.test(subject)) continue;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -214,9 +214,15 @@ function selectBody(parsed: ParsedEmail): string {
 function extractForwardedFrom(body: string): string | null {
   const fwdMatch = body.match(/-+\s*(?:Forwarded message|Mensaje reenviado)\s*-+/i);
   if (!fwdMatch || fwdMatch.index === undefined) return null;
-  // Look for "From: ... <addr>" within 500 chars after the marker.
+  // Look for "From:" (English Gmail) or "De:" (Spanish Gmail) within
+  // 500 chars after the marker. Gmail localizes the header key per
+  // the account's UI language, so supporting both keeps us aligned
+  // with the localized "Forwarded message" / "Mensaje reenviado"
+  // marker variants above.
   const tail = body.slice(fwdMatch.index, fwdMatch.index + 500);
-  const fromMatch = tail.match(/^From:\s*(?:[^<\n]*?<)?([^<>\s\n,]+@[^<>\s\n,]+)/im);
+  const fromMatch = tail.match(
+    /^(?:From|De):\s*(?:[^<\n]*?<)?([^<>\s\n,]+@[^<>\s\n,]+)/im,
+  );
   return fromMatch ? normalizeFrom(fromMatch[1]) : null;
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -182,6 +182,32 @@ describe('verifyForwarder', () => {
     expect(verifyForwarder(header, 'owner@Example.COM')).toBe(true);
   });
 
+  it('treats Gmail addresses with different dot placements as the same mailbox', () => {
+    // Google ignores dots in the gmail.com local-part. Outbound SPF
+    // stamps smtp.mailfrom with whichever canonical form the account
+    // uses, which may differ from the form the deployer put in
+    // TRUSTED_FORWARDER. Both sides get dot-stripped before compare.
+    const withDots =
+      'mx.cloudflare.com; spf=pass smtp.mailfrom=fo.o.bar@gmail.com';
+    const withoutDots = 'foobar@gmail.com';
+    expect(verifyForwarder(withDots, withoutDots)).toBe(true);
+    // And the reverse — TRUSTED_FORWARDER with dots, header without.
+    const headerNoDots =
+      'mx.cloudflare.com; spf=pass smtp.mailfrom=foobar@gmail.com';
+    const trustedWithDots = 'fo.o.bar@gmail.com';
+    expect(verifyForwarder(headerNoDots, trustedWithDots)).toBe(true);
+    // Googlemail.com is the same Google mailbox as gmail.com (Google
+    // owns both); same dot-insensitivity applies.
+    const googlemailHeader =
+      'mx.cloudflare.com; spf=pass smtp.mailfrom=foo.bar@googlemail.com';
+    expect(verifyForwarder(googlemailHeader, 'foobar@googlemail.com')).toBe(true);
+    // Non-Gmail domains are NOT dot-normalized; the comparison stays
+    // literal for providers that treat dots as significant.
+    const nonGmail =
+      'mx.cloudflare.com; spf=pass smtp.mailfrom=fo.o@example.com';
+    expect(verifyForwarder(nonGmail, 'foo@example.com')).toBe(false);
+  });
+
   it('handles a realistic Gmail header whose SPF-result comment contains a comma', () => {
     // Real-world Gmail-forwarded Authentication-Results headers often
     // embed a comma inside the SPF parenthetical comment, e.g.

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -332,6 +332,106 @@ describe('matchEmail — direct unit tests (branch coverage)', () => {
   });
 });
 
+describe('matchEmail — manually forwarded emails (Gmail Forward button)', () => {
+  it('extracts the inner Netflix From from a Gmail-style "Forwarded message" block and matches the travel link', () => {
+    // Shape of a Gmail manual forward: outer From is the family
+    // member's Gmail; the real streaming-service From only exists
+    // inside the quoted block in the body.
+    const parsed: ParsedEmail = {
+      from: 'Family Member <family@gmail.com>',
+      subject: 'Fwd: Your Netflix temporary access code',
+      text: [
+        '',
+        '---------- Forwarded message ---------',
+        'From: Netflix <info@account.netflix.com>',
+        'Date: Fri, 27 Mar 2026 at 16:03',
+        'Subject: Your Netflix temporary access code',
+        'To: <codes@example.com>',
+        '',
+        'Get Code',
+        '[https://www.netflix.com/account/travel/verify?nftoken=FAKE_TOKEN]',
+      ].join('\n'),
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result?.service).toBe('netflix-household');
+    expect(result?.type).toBe('household');
+    expect(result?.value).toBe(
+      'https://www.netflix.com/account/travel/verify?nftoken=FAKE_TOKEN',
+    );
+  });
+
+  it('extracts the inner Disney+ From from a Spanish-localized "Mensaje reenviado" block and matches the code', () => {
+    // Gmail localizes the forward marker per account UI language.
+    const parsed: ParsedEmail = {
+      from: 'Family Member <family@gmail.com>',
+      subject: 'Fwd: Tu código de acceso único para Disney+',
+      text: [
+        '',
+        '---------- Mensaje reenviado ---------',
+        'De: Disney+ <disneyplus@trx.mail2.disneyplus.com>',
+        'From: Disney+ <disneyplus@trx.mail2.disneyplus.com>',
+        'Asunto: Tu código de acceso único para Disney+',
+        '',
+        'Tu código de verificación es 887766. Expira en 15 minutos.',
+      ].join('\n'),
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result).toEqual({
+      service: 'disney',
+      type: 'code',
+      value: '887766',
+      validForMinutes: 15,
+    });
+  });
+
+  it('returns null when the forwarded block exists but the inner From is not a recognized service', () => {
+    const parsed: ParsedEmail = {
+      from: 'Family Member <family@gmail.com>',
+      subject: 'Fwd: newsletter',
+      text: [
+        '---------- Forwarded message ---------',
+        'From: News <news@example.org>',
+        '',
+        'Today in tech: 123456 amazing things happened.',
+      ].join('\n'),
+      html: '',
+    };
+    expect(matchEmail(parsed)).toBeNull();
+  });
+
+  it('returns null when no forwarded-message marker is present and the outer sender is unrecognized', () => {
+    const parsed: ParsedEmail = {
+      from: 'Family Member <family@gmail.com>',
+      subject: 'Your Netflix sign-in code',
+      text: 'This body would have matched if the outer From were info@account.netflix.com, but it is not.',
+      html: '',
+    };
+    expect(matchEmail(parsed)).toBeNull();
+  });
+
+  it('prefers the outer From when it matches a pattern (no false-positive detour through the body)', () => {
+    // If the real sender is Netflix and the body also contains a
+    // forwarded block (unlikely but possible), the outer sender wins.
+    const parsed: ParsedEmail = {
+      from: 'Netflix <info@account.netflix.com>',
+      subject: 'Your Netflix temporary access code',
+      text: [
+        'Get Code',
+        '[https://www.netflix.com/account/travel/verify?nftoken=OUTER_TOKEN]',
+        '',
+        '---------- Forwarded message ---------',
+        'From: Something Else <other@example.org>',
+      ].join('\n'),
+      html: '',
+    };
+    const result = matchEmail(parsed);
+    expect(result?.service).toBe('netflix-household');
+    expect(result?.value).toContain('OUTER_TOKEN');
+  });
+});
+
 describe('matchEmail — defensive branches', () => {
   it('uses match[0] when the subject is missing entirely (undefined)', () => {
     // Covers the `parsed.subject ?? ''` fallback branch where subject is

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -361,8 +361,10 @@ describe('matchEmail — manually forwarded emails (Gmail Forward button)', () =
     );
   });
 
-  it('extracts the inner Disney+ From from a Spanish-localized "Mensaje reenviado" block and matches the code', () => {
-    // Gmail localizes the forward marker per account UI language.
+  it('extracts the inner Disney+ sender from a Spanish Gmail forward (De: + Mensaje reenviado, no English headers at all)', () => {
+    // Gmail localizes BOTH the marker AND the header keys per the
+    // account's UI language. A real Spanish forward contains only
+    // "De:" — no "From:" anywhere — so the regex must accept either.
     const parsed: ParsedEmail = {
       from: 'Family Member <family@gmail.com>',
       subject: 'Fwd: Tu código de acceso único para Disney+',
@@ -370,8 +372,9 @@ describe('matchEmail — manually forwarded emails (Gmail Forward button)', () =
         '',
         '---------- Mensaje reenviado ---------',
         'De: Disney+ <disneyplus@trx.mail2.disneyplus.com>',
-        'From: Disney+ <disneyplus@trx.mail2.disneyplus.com>',
+        'Fecha: vie, 27 mar 2026 a las 16:03',
         'Asunto: Tu código de acceso único para Disney+',
+        'Para: <codes@example.com>',
         '',
         'Tu código de verificación es 887766. Expira en 15 minutos.',
       ].join('\n'),

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,6 +17,13 @@ routes = [
 binding = "OTP_STORE"
 id = "b46c24c9e4754cffb58be2b94a36dce8"
 
+# Enable Workers observability so every email() and fetch() invocation
+# is queryable via the Cloudflare Observability API (and the dashboard's
+# Logs tab) without needing an active `wrangler tail` session. Retains
+# the default sample rate of 1.0 (keep everything).
+[observability]
+enabled = true
+
 [vars]
 TIMEZONE = "America/Santiago"
 DASHBOARD_TITLE = "Streaming Codes"


### PR DESCRIPTION
## Summary

Three focused changes so a family member can smoke-test by clicking **Forward** in Gmail, and so we can diagnose future mail issues without racing \`wrangler tail\`.

### 1. Gmail dot normalization (fixes the silent-reject bug)

Google treats \`foo.bar@gmail.com\` and \`foobar@gmail.com\` as the same mailbox. Outbound SPF stamps \`smtp.mailfrom\` with whichever canonical form the account uses, which may differ from the form committed as \`TRUSTED_FORWARDER\`. \`normalizeAddress\` now strips dots from the local-part for \`gmail.com\` and \`googlemail.com\` on both sides of the compare. Non-Gmail domains stay literal (providers that treat dots as significant aren't over-normalized).

### 2. Manual-forward support

Gmail's Forward button rewrites the outer \`From:\` to *you*; the real streaming-service \`From:\` survives only inside the \`---------- Forwarded message ---------\` quoted block in the body (English or Spanish localized). \`matchEmail\` now tries the outer From first, and if no pattern matches it falls back to extracting an inner \`From:\` from the forwarded block and retrying. Auto-forwarded mail (where outer From IS the streaming service) is unaffected; the inner path only fires when the outer didn't match.

Trust: \`verifyForwarder\` already confirmed the envelope came from the configured \`TRUSTED_FORWARDER\` before \`matchEmail\` runs, so trusting inner body headers is safe.

### 3. Workers observability enabled

\`[observability] enabled = true\` in \`wrangler.toml\`. Every \`email()\` / \`fetch()\` run is queryable via the CF Observability API and the dashboard's Logs tab — no more missing events because \`wrangler tail\` was reconnected at the wrong moment.

## Test plan

- [x] \`npm run typecheck\` — clean (both tsconfigs)
- [x] \`npm test\` — 92/92 pass (+6 new)
- [x] \`npm run test:coverage\` — 100% line coverage on parser / kv / index / dashboard
- [ ] After merge: redeploy, then smoke-test by clicking Forward on the existing Netflix / Disney+ / Max email from any family Gmail account

🤖 Generated with [Claude Code](https://claude.com/claude-code)