### PR TITLE
diag: enrich forwarder-rejection skip log with SPF + domains

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,12 +123,24 @@ export default {
   ): Promise<void> {
     const authResults = message.headers.get('Authentication-Results');
     if (!verifyForwarder(authResults, env.TRUSTED_FORWARDER)) {
-      // Redact both envelope parties. In the Gmail-forwarded flow,
-      // message.from IS the trusted forwarder's Gmail address — logging
-      // it on a transient SPF failure would leak the forwarder identity
-      // into Worker logs, contrary to the project's privacy stance.
-      // message.to is similarly a private inbound routing address.
-      console.log('skip: forwarder verification failed (envelope rejected)');
+      // Log a redacted breakdown of what the envelope produced vs what
+      // we were configured to trust. No full addresses / local-parts —
+      // only SPF result, mailfrom domain, and configured domain. This
+      // is enough to diagnose the two common failure modes (Gmail
+      // stamping a different domain like googlemail.com / SRS rewrite,
+      // or an empty TRUSTED_FORWARDER secret) without leaking either
+      // party's identity into Worker logs.
+      const stripped = (authResults ?? '').replace(/\([^)]*\)/g, '');
+      const spfResult = stripped.match(/\bspf=(\w+)/i)?.[1] ?? 'absent';
+      const mailfromMatch = stripped.match(/\bsmtp\.mailfrom=([^\s;()]+)/i);
+      const gotDomain = mailfromMatch
+        ? (normalizeAddress(mailfromMatch[1]).split('@')[1] ?? 'malformed')
+        : 'absent';
+      const configuredDomain =
+        normalizeAddress(env.TRUSTED_FORWARDER).split('@')[1] ?? 'malformed';
+      console.log(
+        `skip: forwarder verification failed (envelope rejected) spf=${spfResult} mailfrom-domain=${gotDomain} configured-domain=${configuredDomain}`,
+      );
       return;
     }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -279,7 +279,13 @@ describe('email() handler', () => {
     // Privacy: the skip log must NOT include the envelope from/to or
     // any authentication header content.
     expect(logs).toHaveLength(1);
-    expect(logs[0]).toBe('skip: forwarder verification failed (envelope rejected)');
+    // New diagnostic envelope line: prefix intact, plus SPF result and
+    // the two normalized domains (no local-parts).
+    expect(logs[0]).toMatch(
+      /^skip: forwarder verification failed \(envelope rejected\) spf=fail mailfrom-domain=example\.com configured-domain=example\.com$/,
+    );
+    // Neither the envelope address nor the configured TRUSTED_FORWARDER
+    // local-part must appear in the log — domain-only is intentional.
     expect(logs[0]).not.toContain('owner@example.com');
     expect(logs[0]).not.toContain('codes@example.com');
   });


### PR DESCRIPTION
Replaces the bare \`skip: forwarder verification failed (envelope rejected)\` log with the SPF result, the mailfrom domain, and the configured TRUSTED_FORWARDER domain — enough to distinguish the three common failure modes (SPF actually fails; mailfrom absent; Gmail stamping a different domain like googlemail.com or an SRS bounce envelope). Domain-only; no local-parts leak.

## Test plan

- [x] \`npm test\` — 92/92 pass; the no-PII-in-logs assertions still hold
- [ ] After merge + redeploy, have the owner re-forward an OTP from the same account and look at the Worker logs — the domains in the new log will tell us exactly why dot normalization didn't save this case