### PR TITLE
diag: dump inbound header names on forwarder skip

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,24 @@ export default {
   ): Promise<void> {
     const authResults = message.headers.get('Authentication-Results');
     if (!verifyForwarder(authResults, env.TRUSTED_FORWARDER)) {
+      // ONE-SHOT DIAGNOSTIC (diag/header-keys-dump): when verification
+      // fails, dump every header NAME CF handed us so we can see
+      // whether Authentication-Results is actually present under a
+      // different key (e.g. ARC-Authentication-Results). No values
+      // are logged here — names only — to keep the diagnostic
+      // PII-safe. This branch exists to resolve the "spf=absent"
+      // mystery; remove once the root header name is known.
+      try {
+        const names: string[] = [];
+        for (const name of message.headers.keys()) names.push(name);
+        const hasAuth = message.headers.get('Authentication-Results');
+        const hasArc = message.headers.get('ARC-Authentication-Results');
+        console.log(
+          `diag: header-names=[${names.join(',')}] Authentication-Results.length=${hasAuth?.length ?? 0} ARC-Authentication-Results.length=${hasArc?.length ?? 0}`,
+        );
+      } catch (e) {
+        console.log(`diag: header-dump failed ${e instanceof Error ? e.message : String(e)}`);
+      }
       // Log a redacted breakdown of what the envelope produced vs what
       // we were configured to trust. No full addresses / local-parts —
       // only SPF result, mailfrom domain, and configured domain. This

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -276,18 +276,19 @@ describe('email() handler', () => {
     await worker.email!(message, env, fakeCtx());
 
     expect(kv.puts).toHaveLength(0);
-    // Privacy: the skip log must NOT include the envelope from/to or
-    // any authentication header content.
-    expect(logs).toHaveLength(1);
-    // New diagnostic envelope line: prefix intact, plus SPF result and
-    // the two normalized domains (no local-parts).
-    expect(logs[0]).toMatch(
+    // The skip path emits the primary rejection log. A diagnostic
+    // header-dump line is also emitted (one-shot, see src/index.ts)
+    // — allow extra diag lines but require the rejection line.
+    const skip = logs.find((l) => l.startsWith('skip: forwarder verification failed'));
+    expect(skip).toMatch(
       /^skip: forwarder verification failed \(envelope rejected\) spf=fail mailfrom-domain=example\.com configured-domain=example\.com$/,
     );
     // Neither the envelope address nor the configured TRUSTED_FORWARDER
-    // local-part must appear in the log — domain-only is intentional.
-    expect(logs[0]).not.toContain('owner@example.com');
-    expect(logs[0]).not.toContain('codes@example.com');
+    // local-part must appear in any log line — domain-only is intentional.
+    for (const line of logs) {
+      expect(line).not.toContain('owner@example.com');
+      expect(line).not.toContain('codes@example.com');
+    }
   });
 
   it('writes nothing when the Authentication-Results header is missing', async () => {


### PR DESCRIPTION
One-shot diagnostic to figure out why `message.headers.get('Authentication-Results')` is null even though CF's MX reports spf=pass/dkim=pass/arc=pass at MX time.

Logs only header NAMES (no values) plus the lengths of Authentication-Results / ARC-Authentication-Results if either is present. Remove once root cause is known.