### PR TITLE
fix: trust envelope-from directly (drop Authentication-Results parsing)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,15 +70,14 @@ export function verifyForwarder(
 /**
  * Lowercase, trim surrounding whitespace, strip a single layer of
  * angle brackets, and — for gmail.com / googlemail.com addresses —
- * remove dots from the local-part. Used for smtp.mailfrom values
+ * remove dots from the local-part. Used for envelope-from values
  * (sometimes `<a@b>`) and the configured TRUSTED_FORWARDER value.
  *
  * Gmail dot normalization: Google treats `foo.bar@gmail.com` and
- * `foobar@gmail.com` as the same mailbox. Outbound SPF stamps the
- * envelope with whichever canonical form the account uses, which may
- * differ from the form the deployer configured in TRUSTED_FORWARDER.
- * Stripping dots on both sides makes the comparison correct for any
- * variant of a Gmail address.
+ * `foobar@gmail.com` as the same mailbox. The owner's envelope-from
+ * alternates between canonical forms (e.g. with vs. without dots), so
+ * stripping dots on both sides before comparison makes the check
+ * correct for any variant of a Gmail address.
  */
 function normalizeAddress(value: string): string {
   const bare = value.trim().replace(/^<|>$/g, '').trim().toLowerCase();
@@ -113,10 +112,11 @@ export default {
       for (const name of message.headers.keys()) names.push(name);
       console.log(
         `skip: forwarder verification failed` +
-          ` envelope-from=${message.from} envelope-to=${message.to}` +
-          ` configured-forwarder=${env.TRUSTED_FORWARDER}` +
-          ` normalized-from=${normalizeAddress(message.from ?? '')}` +
-          ` normalized-configured=${normalizeAddress(env.TRUSTED_FORWARDER)}` +
+          ` envelope-from=${JSON.stringify(message.from)}` +
+          ` envelope-to=${JSON.stringify(message.to)}` +
+          ` configured-forwarder=${JSON.stringify(env.TRUSTED_FORWARDER)}` +
+          ` normalized-from=${JSON.stringify(normalizeAddress(message.from))}` +
+          ` normalized-configured=${JSON.stringify(normalizeAddress(env.TRUSTED_FORWARDER))}` +
           ` matched=false` +
           ` header-names=[${names.join(',')}]`,
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,69 +25,46 @@ const CSP_HEADER =
   "connect-src 'self';";
 
 /**
- * Returns true iff an Authentication-Results header proves the mail
- * transited the configured trusted forwarder (i.e., an spf=pass with
- * smtp.mailfrom matching env.TRUSTED_FORWARDER, case-insensitive).
+ * Returns true iff the envelope-from address matches the configured
+ * trusted forwarder after normalization (case-insensitive, Gmail dots
+ * ignored in the local-part).
  *
  * Threat model: the Worker is exposed at a public Email Routing address,
- * so any sender can reach us. We trust a message ONLY if the receiving
- * MTA (Cloudflare) attests that SPF passed for an envelope-sender
- * (smtp.mailfrom) we own — i.e., the owner's Gmail forwarding path.
- * `smtp.helo` is intentionally NOT accepted on its own: helo is a
- * self-declared hostname and not authenticated by SPF the same way
- * mailfrom is, so a matching helo without a matching mailfrom could be
- * spoofed by any host that claims the hostname.
+ * so any sender can reach us. Trust derives from Cloudflare's receiving
+ * MTA, which has already performed SPF/DKIM/DMARC/ARC checks at ingest
+ * (visible in the Email Routing Activity tab as
+ * `spf=pass dkim=pass arc=pass Spam=Safe`). Cloudflare would not have
+ * delivered the message to this Worker if SPF against the envelope-from
+ * had failed, so a `message.from` we see here is an envelope address
+ * Cloudflare has already authenticated.
  *
- * Underlying assumption (RFC 8601 §5): the Authentication-Results
- * header we read was produced by Cloudflare's receiving MTA, not
- * carried over from the sender. Per RFC 8601 §5.3, a receiver
- * "SHOULD" strip untrusted Authentication-Results headers before
- * adding its own, and Cloudflare Email Routing does so in practice —
- * otherwise an attacker could simply prepend a forged
- * `Authentication-Results: ...; spf=pass smtp.mailfrom=<owner>` line
- * to their message and bypass this check trivially. If that invariant
- * ever changes, this function is not safe and must be rewritten to
- * select the correct (MTA-authored) stanza.
+ * An earlier iteration of this function parsed an
+ * `Authentication-Results` header out of the inbound message. That
+ * approach was wrong: Cloudflare Email Routing does NOT surface a
+ * fresh Authentication-Results header to Workers. Only the sender's
+ * own `ARC-Authentication-Results` (if any) and Cloudflare's envelope
+ * fields pass through. Real inbound mail was being silently dropped
+ * because the Worker-level header parse always failed. See the
+ * "aggressive skip-path logging" diag work on `main` for the evidence.
  *
- * The header is semi-structured (RFC 8601 / 5451): one or more stanzas
- * joined by `;`, each with `method=result` tokens and ptype.property
- * key/values. Multiple Authentication-Results headers may be merged by
- * `Headers.get` into one comma-separated value; we accept either shape.
+ * If Cloudflare ever starts surfacing its own Authentication-Results
+ * header, we could *additionally* verify it — but the envelope match
+ * alone is the load-bearing check, because CF wouldn't have delivered
+ * otherwise.
  */
 export function verifyForwarder(
-  authResultsHeader: string | null,
+  envelopeFrom: string | null,
   trustedForwarder: string,
 ): boolean {
-  if (!authResultsHeader) return false;
+  if (!envelopeFrom) return false;
 
   const normalizedTrusted = normalizeAddress(trustedForwarder);
   if (!normalizedTrusted) return false;
 
-  // Strip RFC 8601 parenthetical comments before splitting. SPF-result
-  // parentheticals commonly contain commas
-  // (e.g. "spf=pass (google.com: domain of X designates Y as permitted
-  // sender, allow) smtp.mailfrom=..."), and splitting on `,` inside a
-  // comment would fragment a single stanza so neither fragment carries
-  // both spf=pass and smtp.mailfrom — dropping legitimate mail.
-  // Comments are documentation, not semantic, so removing them is safe.
-  const withoutComments = authResultsHeader.replace(/\([^)]*\)/g, '');
+  const normalizedFrom = normalizeAddress(envelopeFrom);
+  if (!normalizedFrom) return false;
 
-  // Split on both `;` (intra-header segmentation) and `,` (multiple
-  // headers merged by Headers.get). Each resulting segment is checked
-  // independently for an spf=pass + matching smtp.mailfrom pair.
-  const segments = withoutComments.split(/[;,]/);
-  for (const segment of segments) {
-    const spfMatch = segment.match(/\bspf=(\w+)/i);
-    if (!spfMatch) continue;
-    if (spfMatch[1].toLowerCase() !== 'pass') continue;
-
-    const mailfromMatch = segment.match(/\bsmtp\.mailfrom=([^\s;()]+)/i);
-    if (!mailfromMatch) continue;
-
-    if (normalizeAddress(mailfromMatch[1]) === normalizedTrusted) return true;
-  }
-
-  return false;
+  return normalizedFrom === normalizedTrusted;
 }
 
 /**
@@ -121,35 +98,27 @@ export default {
     env: Env,
     _ctx: ExecutionContext,
   ): Promise<void> {
-    const authResults = message.headers.get('Authentication-Results');
-    if (!verifyForwarder(authResults, env.TRUSTED_FORWARDER)) {
+    if (!verifyForwarder(message.from, env.TRUSTED_FORWARDER)) {
       // Verbose by design. This is a low-traffic personal Worker on the
       // owner's CF account, logs are private, and we've been burned by
-      // under-logged skip paths. Dump everything that could explain why
-      // verification failed: every inbound header name, the first 500
-      // chars of both Authentication-Results and ARC-Authentication-
-      // Results (CF Email Routing has been observed forwarding the ARC
-      // variant but not a fresh Authentication-Results), envelope
-      // addresses, and the parsed SPF/mailfrom/configured triple.
+      // under-logged skip paths. Dump the raw + normalized envelope-
+      // from, the raw + normalized configured forwarder, and the
+      // inbound header names (for future diagnostics of any other
+      // drift).
       //
       // Do NOT log extracted OTP values or household URL tokens from
       // here or anywhere else — those are the user-facing secrets the
       // Worker is built to relay and the one thing we always redact.
       const names: string[] = [];
       for (const name of message.headers.keys()) names.push(name);
-      const arcResults = message.headers.get('ARC-Authentication-Results');
-      const stripped = (authResults ?? '').replace(/\([^)]*\)/g, '');
-      const spfResult = stripped.match(/\bspf=(\w+)/i)?.[1] ?? 'absent';
-      const mailfromMatch = stripped.match(/\bsmtp\.mailfrom=([^\s;()]+)/i);
-      const mailfromValue = mailfromMatch ? normalizeAddress(mailfromMatch[1]) : 'absent';
       console.log(
         `skip: forwarder verification failed` +
           ` envelope-from=${message.from} envelope-to=${message.to}` +
           ` configured-forwarder=${env.TRUSTED_FORWARDER}` +
-          ` spf=${spfResult} mailfrom=${mailfromValue}` +
-          ` header-names=[${names.join(',')}]` +
-          ` Authentication-Results=${JSON.stringify((authResults ?? '').slice(0, 500))}` +
-          ` ARC-Authentication-Results=${JSON.stringify((arcResults ?? '').slice(0, 500))}`,
+          ` normalized-from=${normalizeAddress(message.from ?? '')}` +
+          ` normalized-configured=${normalizeAddress(env.TRUSTED_FORWARDER)}` +
+          ` matched=false` +
+          ` header-names=[${names.join(',')}]`,
       );
       return;
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -104,130 +104,60 @@ function fakeCtx(): ExecutionContext {
   } as unknown as ExecutionContext;
 }
 
-// Gmail-style Authentication-Results stanza. Matches the shape documented
-// in the task auth memo. We use owner@example.com so the test file is
-// sanitized (matches the TRUSTED_FORWARDER in makeEnv).
-const GMAIL_AUTH_PASS =
-  'mx.cloudflare.com;' +
-  ' dkim=pass header.i=@account.netflix.com header.s=nflx1 header.b=abc;' +
-  ' spf=pass (cloudflare.com: domain of owner@example.com designates 209.85.220.41 as permitted sender) smtp.mailfrom=owner@example.com;' +
-  ' dmarc=pass (p=REJECT sp=REJECT dis=NONE) header.from=account.netflix.com';
-
 describe('verifyForwarder', () => {
   const trusted = 'owner@example.com';
 
-  it('returns false for a null header', () => {
+  it('returns false for a null envelope-from', () => {
     expect(verifyForwarder(null, trusted)).toBe(false);
   });
 
-  it('returns false for an empty string', () => {
+  it('returns false for an empty-string envelope-from', () => {
     expect(verifyForwarder('', trusted)).toBe(false);
   });
 
-  it('returns true for a typical Gmail-forwarded spf=pass stanza', () => {
-    expect(verifyForwarder(GMAIL_AUTH_PASS, trusted)).toBe(true);
+  it('returns true when envelope-from equals the configured forwarder', () => {
+    expect(verifyForwarder('owner@example.com', trusted)).toBe(true);
   });
 
-  it('returns false when spf=fail even if smtp.mailfrom matches', () => {
-    const header = GMAIL_AUTH_PASS.replace('spf=pass', 'spf=fail');
-    expect(verifyForwarder(header, trusted)).toBe(false);
+  it('rejects a bogus envelope-from even if it looks superficially similar', () => {
+    expect(verifyForwarder('attacker@evil.example', trusted)).toBe(false);
+    expect(verifyForwarder('owner@evil.example', trusted)).toBe(false);
+    expect(verifyForwarder('attacker@example.com', trusted)).toBe(false);
   });
 
-  it('returns false when spf=pass but smtp.mailfrom is a different address', () => {
-    const header = GMAIL_AUTH_PASS.replace(
-      'smtp.mailfrom=owner@example.com',
-      'smtp.mailfrom=attacker@example.com',
-    );
-    expect(verifyForwarder(header, trusted)).toBe(false);
-  });
-
-  it('returns false when spf=pass but smtp.mailfrom is absent (helo-only)', () => {
-    const header =
-      'mx.cloudflare.com; spf=pass (fallback) smtp.helo=mail-sor-f41.example.com';
-    expect(verifyForwarder(header, trusted)).toBe(false);
-  });
-
-  it('returns false when there is no spf= result at all', () => {
-    const header =
-      'mx.cloudflare.com; dkim=pass header.i=@example.com; dmarc=pass header.from=example.com';
-    expect(verifyForwarder(header, trusted)).toBe(false);
-  });
-
-  it('accepts multiple stanzas joined by comma where one matches', () => {
-    const receivingMTA = 'mx.other.net; dkim=none; spf=none';
-    const header = `${receivingMTA}, ${GMAIL_AUTH_PASS}`;
-    expect(verifyForwarder(header, trusted)).toBe(true);
-  });
-
-  it('still matches when stanzas are separated by both ";" and a newline (header folding)', () => {
-    // Regex splits on `;` and `,` only — this passes because the
-    // critical `spf=pass smtp.mailfrom=...` clause is cleanly bounded
-    // by `;` within the second stanza, not because `\n` is a separator.
-    // The test is here to document that newline-folded real-world
-    // headers still work, NOT to claim `\n` is an intentional split point.
-    const receivingMTA = 'mx.other.net; dkim=none; spf=none';
-    const header = `${receivingMTA}\n${GMAIL_AUTH_PASS}`;
-    expect(verifyForwarder(header, trusted)).toBe(true);
-  });
-
-  it('accepts <angle-bracketed> smtp.mailfrom values', () => {
-    const header =
-      'mx.cloudflare.com; spf=pass smtp.mailfrom=<owner@example.com>';
-    expect(verifyForwarder(header, trusted)).toBe(true);
+  it('accepts <angle-bracketed> envelope-from values', () => {
+    expect(verifyForwarder('<owner@example.com>', trusted)).toBe(true);
   });
 
   it('matches case-insensitively on both sides', () => {
-    const header =
-      'mx.cloudflare.com; spf=pass smtp.mailfrom=OWNER@example.com';
-    expect(verifyForwarder(header, 'owner@Example.COM')).toBe(true);
+    expect(verifyForwarder('OWNER@example.com', 'owner@Example.COM')).toBe(true);
   });
 
   it('treats Gmail addresses with different dot placements as the same mailbox', () => {
-    // Google ignores dots in the gmail.com local-part. Outbound SPF
-    // stamps smtp.mailfrom with whichever canonical form the account
-    // uses, which may differ from the form the deployer put in
-    // TRUSTED_FORWARDER. Both sides get dot-stripped before compare.
-    const withDots =
-      'mx.cloudflare.com; spf=pass smtp.mailfrom=fo.o.bar@gmail.com';
-    const withoutDots = 'foobar@gmail.com';
-    expect(verifyForwarder(withDots, withoutDots)).toBe(true);
-    // And the reverse — TRUSTED_FORWARDER with dots, header without.
-    const headerNoDots =
-      'mx.cloudflare.com; spf=pass smtp.mailfrom=foobar@gmail.com';
-    const trustedWithDots = 'fo.o.bar@gmail.com';
-    expect(verifyForwarder(headerNoDots, trustedWithDots)).toBe(true);
+    // Google ignores dots in the gmail.com local-part. The owner's
+    // Gmail alternates between `hermosillaignacio@` and
+    // `hermosilla.ignacio@` canonical forms; outbound envelope stamps
+    // whichever the account uses, which may differ from the form the
+    // deployer put in TRUSTED_FORWARDER. Both sides get dot-stripped
+    // before compare.
+    expect(verifyForwarder('fo.o.bar@gmail.com', 'foobar@gmail.com')).toBe(true);
+    // Reverse — TRUSTED_FORWARDER with dots, envelope without.
+    expect(verifyForwarder('foobar@gmail.com', 'fo.o.bar@gmail.com')).toBe(true);
     // Googlemail.com is the same Google mailbox as gmail.com (Google
     // owns both); same dot-insensitivity applies.
-    const googlemailHeader =
-      'mx.cloudflare.com; spf=pass smtp.mailfrom=foo.bar@googlemail.com';
-    expect(verifyForwarder(googlemailHeader, 'foobar@googlemail.com')).toBe(true);
+    expect(
+      verifyForwarder('foo.bar@googlemail.com', 'foobar@googlemail.com'),
+    ).toBe(true);
     // Non-Gmail domains are NOT dot-normalized; the comparison stays
     // literal for providers that treat dots as significant.
-    const nonGmail =
-      'mx.cloudflare.com; spf=pass smtp.mailfrom=fo.o@example.com';
-    expect(verifyForwarder(nonGmail, 'foo@example.com')).toBe(false);
-  });
-
-  it('handles a realistic Gmail header whose SPF-result comment contains a comma', () => {
-    // Real-world Gmail-forwarded Authentication-Results headers often
-    // embed a comma inside the SPF parenthetical comment, e.g.
-    // "spf=pass (google.com: domain of owner@example.com designates
-    // 209.85.220.41 as permitted sender, allow) smtp.mailfrom=...".
-    // The comma inside the comment must NOT fragment the stanza, or
-    // legitimate forwarded mail drops silently.
-    const header =
-      'mx.cloudflare.com; ' +
-      'dkim=pass header.i=@account.netflix.com; ' +
-      'spf=pass (google.com: domain of owner@example.com designates 209.85.220.41 as permitted sender, allow) smtp.mailfrom=owner@example.com; ' +
-      'dmarc=pass header.from=account.netflix.com';
-    expect(verifyForwarder(header, trusted)).toBe(true);
+    expect(verifyForwarder('fo.o@example.com', 'foo@example.com')).toBe(false);
   });
 
   it('returns false when TRUSTED_FORWARDER is empty/whitespace', () => {
     // Defensive: an empty TRUSTED_FORWARDER must NEVER cause a vacuous
-    // match. Blank string must not equal blank mailfrom, etc.
-    expect(verifyForwarder(GMAIL_AUTH_PASS, '')).toBe(false);
-    expect(verifyForwarder(GMAIL_AUTH_PASS, '   ')).toBe(false);
+    // match against an empty/missing envelope-from.
+    expect(verifyForwarder('owner@example.com', '')).toBe(false);
+    expect(verifyForwarder('owner@example.com', '   ')).toBe(false);
   });
 });
 
@@ -242,8 +172,8 @@ describe('email() handler', () => {
     const { env, kv } = makeEnv();
     const message = makeMessage({
       raw: loadFixture('disney-signin.eml'),
-      headers: { 'Authentication-Results': GMAIL_AUTH_PASS },
-      from: 'disneyplus@trx.mail2.disneyplus.com',
+      headers: {},
+      from: 'owner@example.com',
     });
 
     await worker.email!(message, env, fakeCtx());
@@ -257,15 +187,12 @@ describe('email() handler', () => {
     expect(stored.subject).toBe('Tu código de acceso único para Disney+');
   });
 
-  it('writes nothing when forwarder verification fails', async () => {
+  it('writes nothing when the envelope-from does not match the trusted forwarder', async () => {
     const { env, kv } = makeEnv();
     const message = makeMessage({
       raw: loadFixture('disney-signin.eml'),
-      headers: {
-        'Authentication-Results':
-          'mx.cloudflare.com; spf=fail smtp.mailfrom=owner@example.com',
-      },
-      from: 'owner@example.com',
+      headers: { 'x-some-header': 'v' },
+      from: 'attacker@evil.example',
       to: 'codes@example.com',
     });
     const logs: string[] = [];
@@ -281,33 +208,21 @@ describe('email() handler', () => {
     // low-traffic private Worker, aggressive logs are fine — only
     // OTP VALUES and household URL tokens are redacted).
     const skip = logs.find((l) => l.startsWith('skip: forwarder verification failed'));
-    expect(skip).toContain('spf=fail');
-    expect(skip).toContain('mailfrom=owner@example.com');
-    expect(skip).toContain('configured-forwarder=owner@example.com');
-    expect(skip).toContain('envelope-from=owner@example.com');
+    expect(skip).toContain('envelope-from=attacker@evil.example');
     expect(skip).toContain('envelope-to=codes@example.com');
-    expect(skip).toContain('header-names=[authentication-results]');
-    expect(skip).toContain('Authentication-Results="mx.cloudflare.com');
-  });
-
-  it('writes nothing when the Authentication-Results header is missing', async () => {
-    const { env, kv } = makeEnv();
-    const message = makeMessage({
-      raw: loadFixture('disney-signin.eml'),
-      headers: {},
-    });
-
-    await worker.email!(message, env, fakeCtx());
-
-    expect(kv.puts).toHaveLength(0);
+    expect(skip).toContain('configured-forwarder=owner@example.com');
+    expect(skip).toContain('normalized-from=attacker@evil.example');
+    expect(skip).toContain('normalized-configured=owner@example.com');
+    expect(skip).toContain('matched=false');
+    expect(skip).toContain('header-names=[x-some-header]');
   });
 
   it('writes nothing when no parser pattern matches (unknown sender)', async () => {
     const { env, kv } = makeEnv();
     const message = makeMessage({
       raw: loadFixture('random-newsletter.eml'),
-      headers: { 'Authentication-Results': GMAIL_AUTH_PASS },
-      from: 'newsletter@example.org',
+      headers: {},
+      from: 'owner@example.com',
     });
 
     await worker.email!(message, env, fakeCtx());
@@ -327,8 +242,8 @@ describe('email() handler', () => {
     };
     const message = makeMessage({
       raw: loadFixture('disney-signin.eml'),
-      headers: { 'Authentication-Results': GMAIL_AUTH_PASS },
-      from: 'disneyplus@trx.mail2.disneyplus.com',
+      headers: {},
+      from: 'owner@example.com',
     });
     const logs: string[] = [];
     vi.mocked(console.log).mockImplementation((msg: string) => {
@@ -353,8 +268,8 @@ describe('email() handler', () => {
     };
     const message = makeMessage({
       raw: loadFixture('disney-signin.eml'),
-      headers: { 'Authentication-Results': GMAIL_AUTH_PASS },
-      from: 'disneyplus@trx.mail2.disneyplus.com',
+      headers: {},
+      from: 'owner@example.com',
     });
     const logs: string[] = [];
     vi.mocked(console.log).mockImplementation((msg: string) => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -129,6 +129,13 @@ describe('verifyForwarder', () => {
     expect(verifyForwarder('<owner@example.com>', trusted)).toBe(true);
   });
 
+  it('accepts <angle-bracketed> TRUSTED_FORWARDER values (operator-error tolerance)', () => {
+    // If the secret is misconfigured with angle brackets, normalization
+    // strips them from both sides — so a plain envelope-from still
+    // matches an angle-bracketed configured value.
+    expect(verifyForwarder('owner@example.com', '<owner@example.com>')).toBe(true);
+  });
+
   it('matches case-insensitively on both sides', () => {
     expect(verifyForwarder('OWNER@example.com', 'owner@Example.COM')).toBe(true);
   });
@@ -208,11 +215,14 @@ describe('email() handler', () => {
     // low-traffic private Worker, aggressive logs are fine — only
     // OTP VALUES and household URL tokens are redacted).
     const skip = logs.find((l) => l.startsWith('skip: forwarder verification failed'));
-    expect(skip).toContain('envelope-from=attacker@evil.example');
-    expect(skip).toContain('envelope-to=codes@example.com');
-    expect(skip).toContain('configured-forwarder=owner@example.com');
-    expect(skip).toContain('normalized-from=attacker@evil.example');
-    expect(skip).toContain('normalized-configured=owner@example.com');
+    // Envelope fields are JSON.stringify'd in the log to prevent a
+    // malformed SMTP envelope (containing whitespace or newlines) from
+    // fragmenting the structured log line.
+    expect(skip).toContain('envelope-from="attacker@evil.example"');
+    expect(skip).toContain('envelope-to="codes@example.com"');
+    expect(skip).toContain('configured-forwarder="owner@example.com"');
+    expect(skip).toContain('normalized-from="attacker@evil.example"');
+    expect(skip).toContain('normalized-configured="owner@example.com"');
     expect(skip).toContain('matched=false');
     expect(skip).toContain('header-names=[x-some-header]');
   });


### PR DESCRIPTION
## Summary

- `verifyForwarder` now compares `message.from` to `TRUSTED_FORWARDER` directly (with the existing Gmail-dot/case-insensitive normalization) instead of parsing an `Authentication-Results` header that Cloudflare Email Routing never actually surfaces to Workers.
- Skip-path log updated: drops `spf=`/`mailfrom=`/`Authentication-Results=`/`ARC-Authentication-Results=` dumps (no longer semantic); adds `normalized-from`, `normalized-configured`, `matched=false`. Keeps `envelope-from`, `envelope-to`, `configured-forwarder`, and `header-names=[...]` for diagnostics.
- Tests: dropped 7 header-parsing cases that no longer apply; kept dot/case/angle-bracket/empty-forwarder equivalence; added explicit positive match and attacker-envelope rejection cases. 85/85 passing, 100% line coverage on `src/index.ts`.

## Why the old design was wrong

The aggressive skip-path logging from #18/#20/#22 produced the evidence: on real forwarded mail arriving at `codes@ignaciohermosilla.com`, `message.headers.get('Authentication-Results')` returns `""`. The only auth-adjacent header present is Gmail's own `ARC-Authentication-Results: i=1; mx.google.com; arc=none` — a first-hop ARC entry, no chain. CF does NOT add its own `Authentication-Results` header for the Worker to read.

CF's receiving MTA *does* perform SPF/DKIM/DMARC/ARC at ingest — you can see `spf=pass dkim=pass arc=pass Spam=Safe` in the Email Routing Activity tab. CF would not have delivered the message to this Worker if SPF against the envelope-from had failed. So trust derives from CF's MX-level SPF, not from a Worker-level header parse, and the correct Worker-side check is simply: does the CF-attested envelope-from match our configured forwarder?

## Threat model (now documented in `src/index.ts`)

- Worker is exposed at a public Email Routing address, so any sender can reach it.
- CF's MX gates envelope-from authenticity via SPF before invoking the Worker.
- Worker confirms the envelope-from equals `TRUSTED_FORWARDER` (case- and Gmail-dot-insensitive).
- Gmail dot normalization is preserved because the owner's envelope alternates between `hermosillaignacio@gmail.com` and `hermosilla.ignacio@gmail.com` canonical forms.

## Open question (not implemented — for discussion)

Should we expand `TRUSTED_FORWARDER` to a list (`TRUSTED_FORWARDERS`) so family members can forward their own OTPs, rather than funneling everything through the owner's Gmail?

Tradeoffs:
- Each member's canonical envelope-from would need to be enumerated; ongoing maintenance as accounts change.
- Gmail dot normalization already covers the owner's canonical-form drift; similar story per-family-member.
- Alternative: keep single-forwarder; siblings forward to owner first, owner's filter re-forwards to `codes@`. Simpler, but adds a hop and couples all family forwarding to one inbox.

No code change in this PR — flagging for the owner to decide before any list expansion.

## Test plan
- [x] `npm test` — 85/85 passing
- [x] `npx tsc --noEmit` — clean
- [x] 100% line coverage on `src/index.ts`
- [ ] After merge + auto-deploy: forward an HBO Max OTP from owner's Gmail and confirm it lands on the dashboard end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)