### PR TITLE
docs: project-scoped Cloudflare MCP config + deploy runbook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "cloudflare@cloudflare": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,9 @@ dist/
 coverage/
 *.log
 .DS_Store
-# Per-project Claude settings — never commit
-.claude/
+# Per-user Claude Code settings stay local; the shared project config
+# (.claude/settings.json) IS committed so every teammate — and every
+# fresh Claude session — picks up the same enabled plugins (e.g. the
+# Cloudflare plugin bundle) without manual setup.
+.claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,140 @@
+# Deploy runbook
+
+Instructions for anyone (Claude included) picking up `otp-please` and
+shipping a change. Deliberately manual — this Worker has no CI deploy
+step, because a personal OTP relay doesn't justify the complexity of a
+push-to-main pipeline plus API-token secret management.
+
+## What's already wired up for you
+
+- **`.claude/settings.json`** enables the `cloudflare@cloudflare` plugin
+  bundle. Launching Claude Code in this directory auto-loads these MCP
+  servers (after the one-time "allow plugin?" prompt):
+  - `cloudflare-observability` — query the Worker's structured logs.
+    The single most useful MCP here; see the query recipe below.
+  - `cloudflare-bindings` — inspect KV namespaces / other bindings
+    without leaving the session.
+  - `cloudflare-api` — one-shot reads against the REST API (Access
+    policies, Email Routing rules, zone DNS, etc.).
+  - `cloudflare-docs` — docs search grounded in Cloudflare's current
+    reference. Prefer it over recalled-from-training answers for
+    anything Workers- or Email-Routing-specific.
+  - `cloudflare-builds` — returns empty for this Worker (no Workers
+    Builds config; we deploy via `wrangler` CLI). Still enabled in
+    case the project migrates later.
+- **`wrangler.toml`** holds the public config: name, routes, KV binding
+  id, observability, non-secret vars. Secrets are NOT in this file.
+- **`.dev.vars.example`** documents the env vars `wrangler dev` needs.
+  Copy to `.dev.vars` locally for dev; never commit real values.
+
+## Local dev
+
+```sh
+npm ci
+cp .dev.vars.example .dev.vars   # fill in TRUSTED_FORWARDER etc.
+npm run test                     # vitest, ~300ms
+npm run typecheck
+npx wrangler dev                 # local Worker, no KV/email triggers
+```
+
+`wrangler dev` cannot receive real inbound mail — Email Routing only
+runs in production. For email-handler changes, unit tests (which drive
+`ForwardableEmailMessage` test doubles) are the fast-feedback loop.
+
+## Shipping a change
+
+1. Branch: `git checkout -b <type>/<slug>`. **Do not edit on `main`.**
+2. Write the change + tests. Keep coverage ~100% on `src/index.ts`
+   (the email handler is the load-bearing path).
+3. `npm test && npx tsc --noEmit` — both must be green.
+4. Push, open a PR. The `.github/workflows/claude-review.yml` action
+   will run AI review; if the repo owner opens it, auto-approve +
+   auto-merge fire after the review comments land.
+5. `gh pr merge <n> --squash --delete-branch` once reviews clear.
+6. **Deploy manually** (there is no post-merge deploy workflow):
+
+   ```sh
+   git checkout main && git pull
+   npx wrangler deploy
+   ```
+
+   Expected output names the bindings, the uploaded size, the custom
+   domain trigger, and a new `Current Version ID`. Note that ID — it's
+   how you correlate the next smoke test's logs to this deploy.
+
+7. Smoke test: forward a real OTP email (HBO Max / Disney+ / Netflix)
+   from the configured Gmail account. The dashboard at
+   `codes.ignaciohermosilla.com` should refresh within seconds.
+   Verify via the observability query below that an `info: stored …`
+   event landed under the new version id.
+
+## Secrets
+
+All secrets live as Worker secrets, not in `wrangler.toml` or the
+repo.
+
+- `TRUSTED_FORWARDER` — the Gmail address the owner's filter forwards
+  from. Gmail dot-normalization means `foo.bar@gmail.com` and
+  `foobar@gmail.com` compare equal, but setting the canonical form the
+  account actually sends as (check the Email Routing Activity tab for
+  recent envelope-from values) keeps logs readable.
+
+  ```sh
+  npx wrangler secret put TRUSTED_FORWARDER
+  ```
+
+No other secrets are required.
+
+## Confirming a deploy via logs
+
+Structured log events are queryable through the
+`cloudflare-observability` MCP. Useful recipe for "did my deploy land
+and is it ingesting mail cleanly?":
+
+- `view: events`
+- filter `$metadata.service = otp-please`
+- filter `$metadata.message regex ^(info:|skip:|err:)`
+- timeframe `-30m`
+
+`info: stored …` = mail ingested + KV write succeeded. `skip: …` =
+envelope rejected or no parser matched (verbose diagnostics are
+attached — envelope-from, configured-forwarder, the parsed subject).
+`err: …` = KV outage path. Zero `skip:` / `err:` in a 30-min window
+after a smoke test means the deploy is healthy.
+
+The `scriptVersion.id` on each event matches the `Current Version ID`
+printed by `wrangler deploy` — use it to tell post-deploy events apart
+from pre-deploy ones.
+
+## Threat-model reminder
+
+The Worker trusts `message.from` (the SMTP envelope-from) directly,
+after Gmail-dot / case normalization, against `TRUSTED_FORWARDER`.
+**Cloudflare's receiving MTA has already verified SPF** for that
+envelope — CF would not have delivered the message otherwise. We do
+**not** parse `Authentication-Results` in the Worker, because CF Email
+Routing does not surface a fresh Authentication-Results header. An
+earlier iteration of the Worker did, and silently rejected every
+legitimate forward. If you find yourself reaching for header parsing,
+re-read the JSDoc on `verifyForwarder` in `src/index.ts`.
+
+## Operator pitfalls seen in the field
+
+- **Low-traffic private Worker → aggressive logs are fine.** The
+  `skip:` path dumps raw + normalized envelope values and all inbound
+  header names. Only the extracted OTP code and the Netflix household
+  URL token are ever redacted. Do not dial this back "for safety" —
+  the owner has explicitly chosen this tradeoff, and diagnosing a
+  parser-drift bug without it is painful.
+- **Gmail canonical-form drift.** The owner's envelope-from alternates
+  between `hermosillaignacio@` and `hermosilla.ignacio@` forms. If a
+  forward ever stops flowing, check the Email Routing Activity tab for
+  the current envelope — if it's shifted to a form outside the
+  configured dot-normalization (e.g. a `+alias` tag), update
+  `TRUSTED_FORWARDER`.
+- **`wrangler dev` cannot exercise the email handler.** It has no
+  `ForwardableEmailMessage` shim. Trust the unit tests and deploy to
+  production to smoke-test real mail flow.
+- **`workers_builds_list_builds` returns empty** on this Worker. Not a
+  bug — there's no Workers Builds config. The deploy-is-healthy signal
+  is the observability query above, not Workers Builds.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -46,7 +46,10 @@ runs in production. For email-handler changes, unit tests (which drive
 1. Branch: `git checkout -b <type>/<slug>`. **Do not edit on `main`.**
 2. Write the change + tests. Keep coverage ~100% on `src/index.ts`
    (the email handler is the load-bearing path).
-3. `npm test && npx tsc --noEmit` — both must be green.
+3. `npm test && npm run typecheck` — both must be green. (The
+   `typecheck` script runs `tsc --noEmit` against both
+   `tsconfig.json` and `tsconfig.test.json`, so type errors in tests
+   are caught too.)
 4. Push, open a PR. The `.github/workflows/claude-review.yml` action
    will run AI review; if the repo owner opens it, auto-approve +
    auto-merge fire after the review comments land.
@@ -54,7 +57,7 @@ runs in production. For email-handler changes, unit tests (which drive
 6. **Deploy manually** (there is no post-merge deploy workflow):
 
    ```sh
-   git checkout main && git pull
+   git checkout main && git pull --ff-only
    npx wrangler deploy
    ```
 
@@ -126,12 +129,16 @@ re-read the JSDoc on `verifyForwarder` in `src/index.ts`.
   URL token are ever redacted. Do not dial this back "for safety" —
   the owner has explicitly chosen this tradeoff, and diagnosing a
   parser-drift bug without it is painful.
-- **Gmail canonical-form drift.** The owner's envelope-from alternates
-  between `hermosillaignacio@` and `hermosilla.ignacio@` forms. If a
-  forward ever stops flowing, check the Email Routing Activity tab for
-  the current envelope — if it's shifted to a form outside the
-  configured dot-normalization (e.g. a `+alias` tag), update
-  `TRUSTED_FORWARDER`.
+- **Gmail canonical-form drift.** Gmail treats `john.doe@gmail.com`
+  and `johndoe@gmail.com` as the same mailbox, and outbound mail can
+  be stamped with either canonical form depending on how the account
+  was provisioned. `normalizeAddress` in `src/index.ts` strips dots
+  from Gmail/googlemail local-parts on both sides of the comparison
+  so that drift doesn't break verification. If a forward ever stops
+  flowing, check the Email Routing Activity tab for the current
+  envelope-from — if it's shifted to a form outside dot-normalization
+  (e.g. a `+alias` tag), update the `TRUSTED_FORWARDER` secret to
+  match.
 - **`wrangler dev` cannot exercise the email handler.** It has no
   `ForwardableEmailMessage` shim. Trust the unit tests and deploy to
   production to smoke-test real mail flow.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ No home server. No Docker. All compute runs on Cloudflare's edge.
 │  Cloudflare Worker `otp-please`                      │
 │                                                      │
 │  email() handler:                                    │
-│   - Verifies Authentication-Results (spf=pass +      │
-│     smtp.mailfrom matches TRUSTED_FORWARDER)         │
+│   - Verifies envelope-from matches TRUSTED_FORWARDER │
+│     (CF's MX has already attested SPF at ingest)     │
 │   - Parses MIME via postal-mime                      │
 │   - Per-service pattern matching                     │
 │   - Writes StoredEntry to KV with 1h grace TTL       │
@@ -157,7 +157,7 @@ npx wrangler kv key get --binding=OTP_STORE entry:netflix
 
 Common failure modes and what they mean:
 
-- **`skip: forwarder verification failed (envelope rejected)`** — the inbound message's `Authentication-Results` header did not contain an `spf=pass` with an `smtp.mailfrom` matching your configured `TRUSTED_FORWARDER`. Either the secret isn't set (run `npx wrangler secret put TRUSTED_FORWARDER`), or the filter is forwarding from a different Gmail account than the one you configured. Confirm in Gmail's filter settings.
+- **`skip: forwarder verification failed`** — the inbound message's envelope-from did not match your configured `TRUSTED_FORWARDER` (after Gmail-dot/case normalization). Either the secret isn't set (run `npx wrangler secret put TRUSTED_FORWARDER`), or the filter is forwarding from a different Gmail account than the one you configured. The log line includes the raw and normalized envelope-from vs the configured value and an `matched=false` marker — compare those to what you see in Gmail's filter settings and in the Cloudflare Email Routing Activity tab.
 - **`skip: no pattern matched for "..." from ...`** — the sender address or body didn't match any entry in `PATTERNS`. The log includes the subject and parsed `from`; compare them against `src/parser.ts` and adjust the regex if the service has changed its email template.
 - **`err: KV write failed for <service>: ...`** — a transient KV put failure. The Worker does NOT retry on purpose (see the [Security model](#security-model) below) — the next email from the same service will simply overwrite the key. If you see this repeatedly, check Cloudflare status.
 - **Empty dashboard but `wrangler tail` shows stored entries** — either the codes already expired (their `valid_until` + 1 hour grace elapsed), or the KV namespace id in `wrangler.toml` doesn't match the one the dashboard binding reads from. Run `npx wrangler kv key list --binding=OTP_STORE` to confirm what's actually stored.
@@ -167,8 +167,8 @@ Common failure modes and what they mean:
 
 ### What this Worker trusts
 
-- **That mail arriving at `codes@<yourdomain>` was forwarded through your Gmail account.** This is verified by checking for `spf=pass` plus `smtp.mailfrom=<TRUSTED_FORWARDER>` in the inbound `Authentication-Results` header. Anyone who can forge Google's SPF can bypass this check; anyone who has compromised your Gmail account has bigger problems than a streaming code.
-- **That Cloudflare Email Routing strips any `Authentication-Results` header the sender tried to set themselves** and replaces it with its own, MTA-produced stanza. RFC 8601 §5.3 says a receiver SHOULD do this, and Cloudflare does in practice — without that, the check is trivially spoofable. See the comment block on `verifyForwarder` in `src/index.ts`.
+- **That mail arriving at `codes@<yourdomain>` was forwarded through your Gmail account.** Cloudflare Email Routing's MTA performs SPF/DKIM/DMARC/ARC at ingest (visible in the Email Routing Activity tab as `spf=pass dkim=pass arc=pass Spam=Safe`) and drops anything that fails SPF before this Worker is invoked. So by the time `message.from` reaches the Worker, Cloudflare has already verified the envelope-from is authentic. The Worker compares it to `TRUSTED_FORWARDER` (case-insensitive, Gmail-dot-normalized) and rejects anything else. Anyone who can forge Google's SPF can bypass this; anyone who has compromised your Gmail account has bigger problems than a streaming code.
+- **That Cloudflare Email Routing does NOT forward a fresh `Authentication-Results` header into the Worker.** An earlier version of `verifyForwarder` parsed that header and was silently rejecting every legitimate forward — see the JSDoc on `verifyForwarder` in `src/index.ts` for the full story. The current check relies solely on CF's pre-delivery SPF, which is the correct load-bearing signal.
 - **That Cloudflare Access reliably gates the `fetch()` handler**, except the `/healthz` bypass, and that your family members sign in with the configured OAuth identities.
 
 ### What this Worker does NOT do

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -141,12 +141,12 @@ describe('verifyForwarder', () => {
   });
 
   it('treats Gmail addresses with different dot placements as the same mailbox', () => {
-    // Google ignores dots in the gmail.com local-part. The owner's
-    // Gmail alternates between `hermosillaignacio@` and
-    // `hermosilla.ignacio@` canonical forms; outbound envelope stamps
-    // whichever the account uses, which may differ from the form the
-    // deployer put in TRUSTED_FORWARDER. Both sides get dot-stripped
-    // before compare.
+    // Google ignores dots in the gmail.com local-part — e.g.
+    // `foo.bar@gmail.com` and `foobar@gmail.com` address the same
+    // mailbox, and outbound envelope stamps whichever canonical form
+    // the account uses, which may differ from the form the deployer
+    // put in TRUSTED_FORWARDER. Both sides get dot-stripped before
+    // compare so the check survives that drift.
     expect(verifyForwarder('fo.o.bar@gmail.com', 'foobar@gmail.com')).toBe(true);
     // Reverse — TRUSTED_FORWARDER with dots, envelope without.
     expect(verifyForwarder('foobar@gmail.com', 'fo.o.bar@gmail.com')).toBe(true);


### PR DESCRIPTION
## Summary

- **`.claude/settings.json` now tracked.** It already enabled the `cloudflare@cloudflare` plugin bundle locally; tracking it means a fresh Claude session (or a future collaborator) opens the repo and immediately has `cloudflare-observability`, `cloudflare-bindings`, `cloudflare-api`, `cloudflare-docs`, `cloudflare-builds` available with no manual MCP setup. `.gitignore` narrowed so per-user bits (`.claude/settings.local.json`, `.claude/scheduled_tasks.lock`) still stay local.
- **New `DEPLOY.md` at the repo root.** Claude-oriented runbook covering: what the plugin bundle provides, local dev loop, PR-to-deploy flow (deploy is deliberately manual via `npx wrangler deploy` — a personal OTP relay doesn't warrant a push-to-main pipeline with API-token secret management), secret setup, smoke-test observability query, and the operator pitfalls surfaced during PR #24 (Gmail canonical-form drift, envelope-from trust model rationale, why `workers_builds_list_builds` returns empty on this Worker).
- **README stale-text fix (opportunistic).** Three spots still described the old `Authentication-Results` header parsing: the architecture ASCII diagram, the `skip:` troubleshooting entry, and two Security-model bullets. Post-PR #24 the check is envelope-from direct comparison with Gmail dot normalization; README now reflects that consistently.

## Why no CI deploy?

Considered and rejected. This Worker handles three streaming services for one family. Adding a push-to-main deploy workflow means: `CLOUDFLARE_API_TOKEN` as a repo secret, a workflow file to maintain, a failure surface that can block merges without improving ship speed. `npx wrangler deploy` from a trusted laptop is already ~5 seconds and always correlates to a specific deploy operator. If traffic/scope changes, revisit.

## Test plan
- [x] `npm test` — 86/86 passing (no code changed)
- [x] `npx tsc --noEmit` — clean
- [x] DEPLOY.md instructions walked through against this session's actual workflow — everything referenced exists (files, commands, MCP tool names, observability filters)
- [x] README ASCII diagram + Security model read end-to-end for consistency with `src/index.ts` post-PR #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)