### PR TITLE
feat(dashboard): poll /api every 5s instead of 30s meta refresh

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -7,9 +7,17 @@
 // Design notes:
 //  - Single-file output (no external bundle) so the Worker can serve
 //    it directly. The only third-party asset is Tailwind's CDN.
-//  - Meta-refresh every 30s so expired rows eventually vanish even if
-//    the user never interacts. A per-second JS tick keeps the visible
-//    countdowns fresh between full reloads.
+//  - Freshness strategy is two-layered:
+//      1. Client-side poll of /api every POLL_INTERVAL_MS (5s). When a
+//         service's received_at changes (or flips null↔entry) the
+//         matching <section data-service="..."> is replaced in place.
+//         Scroll, mid-flight copy() feedback on the other cards, and
+//         the 1Hz countdown tick are preserved.
+//      2. A widened <meta http-equiv="refresh" content="300"> as a
+//         last-ditch fallback for the case where JS silently died
+//         (e.g. tab backgrounded for days and the runtime throttled it
+//         into oblivion). 300s is long enough not to interrupt normal
+//         use and short enough to self-heal within a single sitting.
 //  - All user-controlled values flow through escapeHtml() before they
 //    hit the template. Attribute values are always double-quoted.
 
@@ -140,7 +148,7 @@ function renderCodeCard(
 ): string {
   const meta = SERVICE_META[service];
   return [
-    `<section class="rounded-lg border-l-4 ${meta.accentBorder} bg-gray-900 p-4 shadow-sm flex flex-col gap-3">`,
+    `<section data-service="${service}" class="rounded-lg border-l-4 ${meta.accentBorder} bg-gray-900 p-4 shadow-sm flex flex-col gap-3">`,
     `  <h2 class="text-sm uppercase tracking-wide ${meta.accentText} font-semibold">${escapeHtml(meta.name)}</h2>`,
     `  <button type="button" data-code="${escapeHtml(entry.value)}" onclick="copy(this)" `,
     `          class="font-mono text-4xl tracking-widest text-gray-100 bg-gray-800 rounded-md py-4 px-3 transition-colors">`,
@@ -161,7 +169,7 @@ function renderHouseholdCard(
 ): string {
   const meta = SERVICE_META[service];
   return [
-    `<section class="rounded-lg border-l-4 ${meta.accentBorder} bg-gray-900 p-4 shadow-sm flex flex-col gap-3">`,
+    `<section data-service="${service}" class="rounded-lg border-l-4 ${meta.accentBorder} bg-gray-900 p-4 shadow-sm flex flex-col gap-3">`,
     `  <h2 class="text-sm uppercase tracking-wide ${meta.accentText} font-semibold">${escapeHtml(meta.name)}</h2>`,
     `  <a href="${escapeHtml(entry.url)}" target="_blank" rel="noopener noreferrer" `,
     `     class="block text-center font-semibold text-white bg-red-700 hover:bg-red-600 rounded-md py-3 px-4 transition-colors">`,
@@ -178,7 +186,7 @@ function renderHouseholdCard(
 function renderEmptyCard(service: ServiceKey): string {
   const meta = SERVICE_META[service];
   return [
-    `<section class="rounded-lg border-l-4 ${meta.accentBorder} bg-gray-900 p-4 shadow-sm opacity-50 flex flex-col gap-2">`,
+    `<section data-service="${service}" class="rounded-lg border-l-4 ${meta.accentBorder} bg-gray-900 p-4 shadow-sm opacity-50 flex flex-col gap-2">`,
     `  <h2 class="text-sm uppercase tracking-wide ${meta.accentText} font-semibold">${escapeHtml(meta.name)}</h2>`,
     `  <p class="text-gray-400">${escapeHtml(meta.emptyMessage)}</p>`,
     `</section>`,
@@ -195,11 +203,35 @@ function renderCard(
   return renderHouseholdCard(service, entry, now);
 }
 
-// Inline client-side script. Kept small and readable — it does only two
-// things: (1) tap-to-copy feedback and (2) a 1Hz tick that updates the
-// relative time strings. Full-page refresh every 30s (meta http-equiv)
-// handles eventual cleanup of expired cards.
+// Inline client-side script. Responsibilities:
+//  1. copy(): tap-to-copy feedback on code buttons.
+//  2. tick(): 1Hz refresh of relative-time strings on the countdown /
+//     received-ago spans, without touching any other DOM state.
+//  3. poll(): fetch('/api') every POLL_INTERVAL_MS (5s) and diff each
+//     service's received_at against the section's current
+//     data-received-at attribute. On change (including null↔entry
+//     flip) the matching <section data-service="..."> is replaced via
+//     outerHTML. Only cards whose received_at actually changed are
+//     touched — scroll, focus, and any in-flight copy() animation on
+//     other cards are preserved.
+//
+// The SERVICE_META object mirrors the server-side constant of the same
+// name. We duplicate it here (rather than injecting it via data-*)
+// because (a) it's only 3 services × 4 fields and (b) inlining keeps
+// the diff surface obvious if the server-side copy ever changes.
+//
+// escapeHtml / initialCountdownText / initialReceivedText mirror the
+// server helpers in this file so newly-rendered cards look identical
+// to the server-rendered ones. The server is still the source of
+// truth for the initial paint; the client copies exist only for the
+// replacement path.
 const CLIENT_SCRIPT = `
+const POLL_INTERVAL_MS = 5000;
+const SERVICE_META = {
+  'netflix-household': { name: 'Netflix', accentBorder: 'border-red-600', accentText: 'text-red-500', emptyMessage: 'no household request pending' },
+  'disney': { name: 'Disney+', accentBorder: 'border-blue-600', accentText: 'text-blue-400', emptyMessage: 'no recent code' },
+  'max': { name: 'Max', accentBorder: 'border-purple-600', accentText: 'text-purple-400', emptyMessage: 'no recent code' },
+};
 function copy(el) {
   const code = el.dataset.code;
   if (!code) return;
@@ -239,8 +271,90 @@ function tick() {
     el.textContent = m === 0 ? 'received just now' : 'received ' + m + 'm ago';
   });
 }
+function escapeAttr(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+function initialCountdownText(validUntil, now) {
+  const delta = Math.round((Date.parse(validUntil) - now) / 1000);
+  if (delta > 0) {
+    const m = Math.floor(delta / 60);
+    const s = delta % 60;
+    return { text: 'valid for ' + m + 'm ' + String(s).padStart(2, '0') + 's', expired: false };
+  }
+  const expiredSec = -delta;
+  const m = Math.floor(expiredSec / 60);
+  return { text: 'expired ' + m + 'm ago', expired: true };
+}
+function initialReceivedText(receivedAt, now) {
+  const ageSec = Math.max(0, Math.round((now - Date.parse(receivedAt)) / 1000));
+  const m = Math.floor(ageSec / 60);
+  return m === 0 ? 'received just now' : 'received ' + m + 'm ago';
+}
+function renderCardHTML(service, entry) {
+  const meta = SERVICE_META[service];
+  if (!meta) return '';
+  if (!entry) {
+    return '<section data-service="' + service + '" class="rounded-lg border-l-4 ' + meta.accentBorder + ' bg-gray-900 p-4 shadow-sm opacity-50 flex flex-col gap-2">' +
+      '<h2 class="text-sm uppercase tracking-wide ' + meta.accentText + ' font-semibold">' + escapeAttr(meta.name) + '</h2>' +
+      '<p class="text-gray-400">' + escapeAttr(meta.emptyMessage) + '</p>' +
+      '</section>';
+  }
+  const now = Date.now();
+  const cd = initialCountdownText(entry.valid_until, now);
+  const expiredCls = cd.expired ? ' text-red-500' : '';
+  const countdown = '<span data-valid-until="' + escapeAttr(entry.valid_until) + '" class="text-sm text-gray-400' + expiredCls + '">' + escapeAttr(cd.text) + '</span>';
+  const received = '<span data-received-at="' + escapeAttr(entry.received_at) + '" class="text-xs text-gray-500">' + escapeAttr(initialReceivedText(entry.received_at, now)) + '</span>';
+  const header = '<h2 class="text-sm uppercase tracking-wide ' + meta.accentText + ' font-semibold">' + escapeAttr(meta.name) + '</h2>';
+  const shell = '<section data-service="' + service + '" class="rounded-lg border-l-4 ' + meta.accentBorder + ' bg-gray-900 p-4 shadow-sm flex flex-col gap-3">';
+  const tail = '<div class="flex flex-col gap-1">' + countdown + received + '</div></section>';
+  if (entry.type === 'code') {
+    const button = '<button type="button" data-code="' + escapeAttr(entry.value) + '" onclick="copy(this)" class="font-mono text-4xl tracking-widest text-gray-100 bg-gray-800 rounded-md py-4 px-3 transition-colors">' + escapeAttr(entry.value) + '</button>';
+    return shell + header + button + tail;
+  }
+  const link = '<a href="' + escapeAttr(entry.url) + '" target="_blank" rel="noopener noreferrer" class="block text-center font-semibold text-white bg-red-700 hover:bg-red-600 rounded-md py-3 px-4 transition-colors">Approve this device on Netflix</a>';
+  return shell + header + link + tail;
+}
+function currentReceivedAt(section) {
+  const el = section.querySelector('[data-received-at]');
+  return el ? el.getAttribute('data-received-at') : null;
+}
+function poll() {
+  fetch('/api', { cache: 'no-store' }).then((res) => {
+    // 302 to Access login (session expired) lands here too — Access
+    // serves HTML so JSON.parse would throw; treat any non-200 as
+    // "skip this tick, stale DOM is fine".
+    if (!res.ok) return null;
+    return res.json();
+  }).then((data) => {
+    if (!data) return;
+    let changed = false;
+    Object.keys(SERVICE_META).forEach((service) => {
+      const section = document.querySelector('[data-service="' + service + '"]');
+      if (!section) return;
+      const entry = data[service] || null;
+      const newReceivedAt = entry ? entry.received_at : null;
+      if (currentReceivedAt(section) !== newReceivedAt) {
+        section.outerHTML = renderCardHTML(service, entry);
+        changed = true;
+      }
+    });
+    // Only call tick() when something moved — a no-op tick would just
+    // rewrite spans to their current text, wasted work but not wrong.
+    if (changed) tick();
+  }).catch((e) => {
+    // Network blip, JSON parse error, etc. Keep polling on the next
+    // interval. Stale DOM + ticking countdown is an acceptable state.
+    console.warn('poll failed', e);
+  });
+}
 tick();
 setInterval(tick, 1000);
+setInterval(poll, POLL_INTERVAL_MS);
 `.trim();
 
 /**
@@ -265,7 +379,7 @@ export function renderDashboard(data: DashboardData): string {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <meta http-equiv="refresh" content="30">
+  <meta http-equiv="refresh" content="300">
   <title>${escapeHtml(data.title)}</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -316,6 +316,9 @@ function renderCardHTML(service, entry) {
     const button = '<button type="button" data-code="' + escapeAttr(entry.value) + '" onclick="copy(this)" class="font-mono text-4xl tracking-widest text-gray-100 bg-gray-800 rounded-md py-4 px-3 transition-colors">' + escapeAttr(entry.value) + '</button>';
     return shell + header + button + tail;
   }
+  // Link text is Netflix-specific; if a second household-type service is
+  // added, keep this in sync with renderHouseholdCard above (the server
+  // paint) — the two copies will otherwise drift silently.
   const link = '<a href="' + escapeAttr(entry.url) + '" target="_blank" rel="noopener noreferrer" class="block text-center font-semibold text-white bg-red-700 hover:bg-red-600 rounded-md py-3 px-4 transition-colors">Approve this device on Netflix</a>';
   return shell + header + link + tail;
 }
@@ -336,7 +339,7 @@ function poll() {
     Object.keys(SERVICE_META).forEach((service) => {
       const section = document.querySelector('[data-service="' + service + '"]');
       if (!section) return;
-      const entry = data[service] || null;
+      const entry = data[service] ?? null;
       const newReceivedAt = entry ? entry.received_at : null;
       if (currentReceivedAt(section) !== newReceivedAt) {
         section.outerHTML = renderCardHTML(service, entry);

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -97,9 +97,20 @@ describe('renderDashboard — structure and ordering', () => {
     expect(html).toContain('<h1 class="text-2xl font-bold">My Codes</h1>');
   });
 
-  it('includes a meta refresh tag with 30-second interval', () => {
+  it('includes a widened 300-second meta refresh as a JS-dead fallback', () => {
     const html = renderDashboard(defaultData());
-    expect(html).toContain('<meta http-equiv="refresh" content="30">');
+    expect(html).toContain('<meta http-equiv="refresh" content="300">');
+    // The old 30s cadence is replaced by client-side polling; guard against
+    // accidental reintroduction which would cause a full-page reload that
+    // kicks the user out of mid-flight copy animations and trashes scroll.
+    expect(html).not.toContain('content="30"');
+  });
+
+  it('stamps data-service on each card so the poller can locate them', () => {
+    const html = renderDashboard(defaultData());
+    expect(html).toContain('data-service="netflix-household"');
+    expect(html).toContain('data-service="disney"');
+    expect(html).toContain('data-service="max"');
   });
 
   it('emits <html lang="en" class="dark"> so dark mode is the default', () => {
@@ -179,9 +190,18 @@ describe('renderDashboard — code entries', () => {
 
   it('does not render a copy button for an empty entry', () => {
     const html = renderDashboard(defaultData());
-    // No entries populated, so no data-code attributes should exist.
-    expect(html).not.toContain('data-code=');
-    expect(html).not.toContain('onclick="copy(this)"');
+    // Scope to the visible <main> region. The inline <script> also
+    // contains the literal strings "data-code=" and 'onclick="copy(this)"'
+    // inside the client-side card-builder template — that's correct code,
+    // not a rendered button. The test's intent is "no copy button in any
+    // server-rendered card when all entries are null".
+    const mainStart = html.indexOf('<main');
+    const mainEnd = html.indexOf('</main>');
+    expect(mainStart).toBeGreaterThan(-1);
+    expect(mainEnd).toBeGreaterThan(mainStart);
+    const body = html.slice(mainStart, mainEnd);
+    expect(body).not.toContain('data-code=');
+    expect(body).not.toContain('onclick="copy(this)"');
   });
 });
 
@@ -219,10 +239,17 @@ describe('renderDashboard — household entries', () => {
 describe('renderDashboard — empty states', () => {
   it('renders "no recent code" for disney and max (household has its own empty copy)', () => {
     const html = renderDashboard(defaultData());
+    // Scope to <main>: the client-side SERVICE_META mirror in the
+    // inline <script> also contains these emptyMessage strings, which
+    // are correct code (used when polling replaces an entry-populated
+    // card with an empty one), not rendered cards.
+    const mainStart = html.indexOf('<main');
+    const mainEnd = html.indexOf('</main>');
+    const body = html.slice(mainStart, mainEnd);
     // "no recent code" appears for disney and max. Netflix (household)
     // uses "no household request pending" instead.
-    expect(html.match(/no recent code/g)?.length).toBe(2);
-    expect(html).toContain('no household request pending');
+    expect(body.match(/no recent code/g)?.length).toBe(2);
+    expect(body).toContain('no household request pending');
   });
 
   it('renders "no household request pending" for netflix-household with null entry', () => {
@@ -331,5 +358,30 @@ describe('renderDashboard — inline client script', () => {
   it('references the Tailwind CDN script', () => {
     const html = renderDashboard(defaultData());
     expect(html).toContain('https://cdn.tailwindcss.com');
+  });
+});
+
+describe('renderDashboard — client-side polling', () => {
+  it('defines POLL_INTERVAL_MS = 5000', () => {
+    const html = renderDashboard(defaultData());
+    expect(html).toMatch(/const\s+POLL_INTERVAL_MS\s*=\s*5000/);
+  });
+
+  it('defines a poll() function that fetches /api', () => {
+    const html = renderDashboard(defaultData());
+    expect(html).toMatch(/function\s+poll\s*\(/);
+    expect(html).toContain("fetch('/api'");
+  });
+
+  it('schedules poll at POLL_INTERVAL_MS so the cadence is one consistent value', () => {
+    const html = renderDashboard(defaultData());
+    expect(html).toContain('setInterval(poll, POLL_INTERVAL_MS)');
+  });
+
+  it('keeps the 1-second tick interval so countdown text stays live between polls', () => {
+    // Explicit regression guard: the poll must be additive to the existing
+    // per-second tick, not a replacement for it.
+    const html = renderDashboard(defaultData());
+    expect(html).toContain('setInterval(tick, 1000);');
   });
 });


### PR DESCRIPTION
## Summary

- Replace the dashboard's 30s `<meta http-equiv="refresh">` with a client-side poll of `/api` every `POLL_INTERVAL_MS` (5s). No backend change — `/api` already returns the `Record<ServiceKey, StoredEntry | null>` shape the renderer consumes.
- On each tick the client diffs each service's `received_at` against the section's current `data-received-at` and only replaces sections whose `received_at` changed (or flipped `null↔entry`) via `outerHTML`. Scroll, focus, and any in-flight `copy()` animation on other cards are preserved. The existing 1Hz `tick()` continues to run so countdown text stays live between polls.
- Meta refresh is kept but widened to **300s** as a JS-dead fallback (tab backgrounded for days, runtime throttled into oblivion, etc.). Guard-rail test asserts the old 30s value is gone.
- Each `<section>` now carries a `data-service="..."` attribute so the poller can locate the correct card. The inline script duplicates `SERVICE_META` and a handful of render helpers so replacement cards match the server paint.
- CSP unchanged — `connect-src 'self'` already permits `fetch('/api')`.

## Test plan
- [x] `npm test` — 91 passed (was 86; +5 new polling assertions)
- [x] `npm run typecheck` clean
- [x] Coverage on `src/dashboard.ts` still 100% lines/branches/functions
- [ ] Post-merge: `npx wrangler deploy`, record new Worker Version ID
- [ ] Open the dashboard, forward an OTP from Gmail, confirm the card updates within ~5-10s **without** a page flash / scroll jump
- [ ] Verify the new Worker Version ID via the `cloudflare-observability` MCP query from `DEPLOY.md`

## Non-obvious details worth reviewing
- Two existing empty-state tests did naive substring searches (`data-code=`, `no recent code`) that now legitimately appear in the inline script's card-builder template literal. Both were narrowed to the `<main>` region rather than obfuscating the script strings. Intent-preserving, not a weakening.
- The client-side `SERVICE_META` / render helpers are duplicated from the server. A hidden `<script type="application/json">` injection would remove the duplication but adds a load-bearing invariant across two places in the template. At 3 services × 4 fields I preferred the duplication — the diff surface is obvious and co-located.
- `poll()` only calls `tick()` when at least one section was replaced; a no-op tick would just rewrite spans to their current text. Cheap, but wasted work on every 5s poll isn't free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)