### PR TITLE
fix: allow Cloudflare Insights beacon in CSP

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,10 +19,10 @@ import { matchEmail, type ParsedEmail } from './parser';
 // fetches to third parties.
 const CSP_HEADER =
   "default-src 'self'; " +
-  "script-src 'self' https://cdn.tailwindcss.com 'unsafe-inline'; " +
+  "script-src 'self' https://cdn.tailwindcss.com https://static.cloudflareinsights.com 'unsafe-inline'; " +
   "style-src 'self' https://cdn.tailwindcss.com 'unsafe-inline'; " +
   "img-src 'self' data:; " +
-  "connect-src 'self';";
+  "connect-src 'self' https://cloudflareinsights.com;";
 
 /**
  * Returns true iff the envelope-from address matches the configured

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,8 @@ import { matchEmail, type ParsedEmail } from './parser';
 // the dashboard being single-tenant and Access-gated.
 //
 // `img-src 'self' data:` allows inline data URLs if a future card ever
-// wants a small embedded icon; `connect-src 'self'` blocks outbound
-// fetches to third parties.
+// wants a small embedded icon. `connect-src` permits the Cloudflare
+// Insights telemetry beacon; all other outbound fetches are blocked.
 const CSP_HEADER =
   "default-src 'self'; " +
   "script-src 'self' https://cdn.tailwindcss.com https://static.cloudflareinsights.com 'unsafe-inline'; " +


### PR DESCRIPTION
## Summary
- The Cloudflare Insights RUM beacon (`static.cloudflareinsights.com/beacon.min.js`) was blocked by the dashboard CSP, surfacing as a console violation.
- Adds `https://static.cloudflareinsights.com` to `script-src` and `https://cloudflareinsights.com` to `connect-src` (the beacon POSTs telemetry there).
- Tailwind CDN warning is intentionally left in place — will be addressed alongside the upcoming UI redesign.

## Test plan
- [ ] Deploy to QA, load the dashboard, confirm the CSP violation is gone from the console.
- [ ] Confirm web analytics start showing traffic in the Cloudflare dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)