### PR TITLE
chore(dashboard): drop the decorative LIVE eyebrow

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -532,9 +532,8 @@ export function renderDashboard(data: DashboardData): string {
 </head>
 <body class="min-h-screen bg-[oklch(0.18_0.008_55)] text-stone-100 antialiased" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
   <main class="max-w-md mx-auto px-4 pt-8 pb-10 flex flex-col gap-2.5">
-    <header class="flex items-baseline justify-between pb-2 px-1">
+    <header class="pb-2 px-1">
       <h1 class="text-[22px] font-semibold tracking-tight text-stone-100">${escapeHtml(data.title)}</h1>
-      <span class="text-[11px] uppercase tracking-[0.16em] text-stone-500">live</span>
     </header>
     <div class="text-[11px] uppercase tracking-[0.14em] text-stone-500 px-1 pb-0.5">codes</div>
 ${cards}

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -173,10 +173,20 @@ describe('renderDashboard — structure and ordering', () => {
     expect(html).toContain('<meta name="theme-color" content="#1a1714">');
   });
 
-  it('renders the LIVE eyebrow and CODES section label', () => {
+  it('renders the CODES section label above the cards', () => {
     const html = renderDashboard(defaultData());
-    expect(html).toMatch(/>live</);
     expect(html).toMatch(/>codes</);
+  });
+
+  it('does not render a decorative LIVE eyebrow in the header', () => {
+    // Regression guard: the LIVE eyebrow was dropped because it was
+    // decorative (no underlying liveness check). If someone reintroduces
+    // it, they should make it honest (driven by the poll's success
+    // state) rather than a static label.
+    const html = renderDashboard(defaultData());
+    const headerMatch = html.match(/<header[\s\S]*?<\/header>/);
+    expect(headerMatch).not.toBeNull();
+    expect(headerMatch![0]).not.toMatch(/>live</i);
   });
 
   it('includes a widened 300-second meta refresh as a JS-dead fallback', () => {


### PR DESCRIPTION
## Summary

The small "LIVE" label in the header was static decoration — no underlying liveness check, no offline state to contrast with. The ticking countdown already signals the page is alive, so the eyebrow was dressing up the dashboard as something it wasn't.

Header collapses to just the title. Adds a regression-guard test so any future reintroduction is deliberate — and ideally driven by real poll-success state rather than baked copy.

## Test plan

- [x] `npm test` — 109/109 green (+1 regression guard, -1 eyebrow assertion)
- [x] Rendered preview: header now shows only "Family Codes", no corner eyebrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)