### PR TITLE
feat(dashboard): add favicon + apple-touch-icon

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -536,6 +536,8 @@ export function renderDashboard(data: DashboardData): string {
   <meta name="theme-color" content="#1a1714">
   <meta http-equiv="refresh" content="300">
   <title>${escapeHtml(data.title)}</title>
+  <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/ignaciohermosillacornejo/otp-please/main/assets/logo.png">
+  <link rel="apple-touch-icon" href="https://raw.githubusercontent.com/ignaciohermosillacornejo/otp-please/main/assets/logo.png">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="min-h-screen bg-[oklch(0.18_0.008_55)] text-stone-100 antialiased" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">


### PR DESCRIPTION
## Summary
- Add \`<link rel="icon">\` and \`<link rel="apple-touch-icon">\` to the dashboard HTML \`<head>\`, both pointing at the existing kraft-envelope logo at \`assets/logo.png\` (served via \`raw.githubusercontent.com/.../main\`).
- No Worker route, no wrangler config change, no Access bypass rule — the favicon is fetched post-auth anyway (login page is on \`cloudflareaccess.com\`, a different origin), so external URL is simpler and sufficient.
- \`apple-touch-icon\` is included because the dashboard is mobile-first; adding \`codes.ignaciohermosilla.com\` to an iOS home screen is the obvious use case.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 110/110 passing, no dashboard.test.ts changes needed (head-tag additions don't conflict with existing header/footer/card assertions)
- [ ] After merge + \`npx wrangler deploy\`: reload \`codes.ignaciohermosilla.com\` in a fresh tab, confirm the envelope+key favicon appears; add to iOS home screen, confirm the icon renders there too