### PR TITLE
fix(dashboard): declare sizes="180x180" on apple-touch-icon

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -537,7 +537,7 @@ export function renderDashboard(data: DashboardData): string {
   <meta http-equiv="refresh" content="300">
   <title>${escapeHtml(data.title)}</title>
   <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/ignaciohermosillacornejo/otp-please/main/assets/logo.png">
-  <link rel="apple-touch-icon" href="https://raw.githubusercontent.com/ignaciohermosillacornejo/otp-please/main/assets/logo.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://raw.githubusercontent.com/ignaciohermosillacornejo/otp-please/main/assets/logo.png">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="min-h-screen bg-[oklch(0.18_0.008_55)] text-stone-100 antialiased" style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">


### PR DESCRIPTION
## Summary
Add \`sizes="180x180"\` to the \`<link rel="apple-touch-icon">\` tag on the dashboard. Addresses the audit finding from [#39](https://github.com/ignaciohermosillacornejo/otp-please/issues/39) (follow-up on PR #38). Declaring the standard iOS apple-touch-icon size documents intent and suppresses linter warnings in some HTML-validation tools.

Note: the source PNG is 512×512. iOS downscales transparently, so the declaration is aspirational/hygienic, not literal.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 110/110 passing (no test changes needed)

Fixes #39